### PR TITLE
Fix old repo links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,17 +97,17 @@
 
 Init relaase
 
-[Unreleased]: https://github.com/silentsokolov/dbt-clickhouse/compare/v1.0.4...HEAD
-[1.0.4]: https://github.com/silentsokolov/dbt-clickhouse/compare/v1.0.1...v1.0.4
-[1.0.1]: https://github.com/silentsokolov/dbt-clickhouse/compare/v1.0.0...v1.0.1
-[1.0.0]: https://github.com/silentsokolov/dbt-clickhouse/compare/v0.21.1...v1.0.0
-[0.21.1]: https://github.com/silentsokolov/dbt-clickhouse/compare/v0.21.0...v0.21.1
-[0.21.0]: https://github.com/silentsokolov/dbt-clickhouse/compare/v0.20.2...v0.21.0
-[0.20.2]: https://github.com/silentsokolov/dbt-clickhouse/compare/v0.20.1...v0.20.2
-[0.20.1]: https://github.com/silentsokolov/dbt-clickhouse/compare/v0.20.0...v0.20.1
-[0.20.0]: https://github.com/silentsokolov/dbt-clickhouse/compare/v0.19.1.1...v0.20.0
-[0.19.1.1]: https://github.com/silentsokolov/dbt-clickhouse/compare/v0.19.1...v0.19.1.1
-[0.19.1]: https://github.com/silentsokolov/dbt-clickhouse/compare/v0.19.0.2...v0.19.1
-[0.19.0.2]: https://github.com/silentsokolov/dbt-clickhouse/compare/v0.19.0.1...v0.19.0.2
-[0.19.0.1]: https://github.com/silentsokolov/dbt-clickhouse/compare/v0.19.0...v0.19.0.1
-[0.19.0]: https://github.com/silentsokolov/dbt-clickhouse/compare/eb3020a...v0.19.0
+[Unreleased]: https://github.com/ClickHouse/dbt-clickhouse/compare/v1.0.4...HEAD
+[1.0.4]: https://github.com/ClickHouse/dbt-clickhouse/compare/v1.0.1...v1.0.4
+[1.0.1]: https://github.com/ClickHouse/dbt-clickhouse/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/ClickHouse/dbt-clickhouse/compare/v0.21.1...v1.0.0
+[0.21.1]: https://github.com/ClickHouse/dbt-clickhouse/compare/v0.21.0...v0.21.1
+[0.21.0]: https://github.com/ClickHouse/dbt-clickhouse/compare/v0.20.2...v0.21.0
+[0.20.2]: https://github.com/ClickHouse/dbt-clickhouse/compare/v0.20.1...v0.20.2
+[0.20.1]: https://github.com/ClickHouse/dbt-clickhouse/compare/v0.20.0...v0.20.1
+[0.20.0]: https://github.com/ClickHouse/dbt-clickhouse/compare/v0.19.1.1...v0.20.0
+[0.19.1.1]: https://github.com/ClickHouse/dbt-clickhouse/compare/v0.19.1...v0.19.1.1
+[0.19.1]: https://github.com/ClickHouse/dbt-clickhouse/compare/v0.19.0.2...v0.19.1
+[0.19.0.2]: https://github.com/ClickHouse/dbt-clickhouse/compare/v0.19.0.1...v0.19.0.2
+[0.19.0.1]: https://github.com/ClickHouse/dbt-clickhouse/compare/v0.19.0...v0.19.0.1
+[0.19.0]: https://github.com/ClickHouse/dbt-clickhouse/compare/eb3020a...v0.19.0

--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/silentsokolov/dbt-clickhouse/master/etc/chdbt.png" alt="clickhouse dbt logo" width="300"/>
+  <img src="https://raw.githubusercontent.com/ClickHouse/dbt-clickhouse/master/etc/chdbt.png" alt="clickhouse dbt logo" width="300"/>
 </p>
 
-[![build](https://github.com/silentsokolov/dbt-clickhouse/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/silentsokolov/dbt-clickhouse/actions/workflows/build.yml)
+[![build](https://github.com/ClickHouse/dbt-clickhouse/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/ClickHouse/dbt-clickhouse/actions/workflows/build.yml)
 
 # dbt-clickhouse
 
 This plugin ports [dbt](https://getdbt.com) functionality to [Clickhouse](https://clickhouse.tech/).
 
 We do not support older versions of Clickhouse. The plugin uses syntax that requires version 21 or newer.
-
-### Original Author
-ClickHouse wants to thank @silentsokolov for creating this connector and for their valuable contributions.  
 
 ### Installation
 
@@ -89,6 +86,9 @@ You can customize a few test params through environment variables. In order to p
 3. PASSWORD_ENV_VAR_NAME - your ClickHouse password. Default=''
 4. PORT_ENV_VAR_NAME - ClickHouse client port. Default=9000
 5. RUN_DOCKER_ENV_VAR_NAME - Identify whether to run clickhouse-server docker image (see tests/docker-compose.yml). Default=False. Set it to True if you'd like to raise a docker image (assuming docker-compose is installed in your machine) during tests that launches a clickhouse-server. Note: If you decide to run  a docker image you should set PORT_ENV_VAR_NAME to 10900 too.
+
+### Original Author
+ClickHouse wants to thank @[silentsokolov](https://github.com/silentsokolov) for creating this connector and for their valuable contributions.
 
 ## Update 05/31/2022
 * Incremental changes of an incremental model are loaded into a MergeTree table instead of in-memory temporary table. This removed memory limitations - Clickhouse recommends that in-memory table engines should not exceed 100 million rows.


### PR DESCRIPTION
 - Refactor personal links from the old repo
 - Move a block about author in README to the down of the page, because this is not critical information for use