### PR TITLE
Removed single database limitation in get_catalog

### DIFF
--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -145,10 +145,6 @@ class ClickhouseAdapter(SQLAdapter):
 
     def get_catalog(self, manifest):
         schema_map = self._get_catalog_schemas(manifest)
-        if len(schema_map) > 1:
-            dbt.exceptions.raise_compiler_error(
-                f'Expected only one database in get_catalog, found ' f'{list(schema_map)}'
-            )
 
         with executor(self.config) as tpe:
             futures: List[Future[agate.Table]] = []


### PR DESCRIPTION
I removed the single db limitation from get_catalog.

Reason: when using different quoting policies in a dbt project, they are stored as separate schema info. The previous check we did disallowed multiple schema info, and I don't see a good reason not to allow multiple information schema in this case.

@silentsokolov, @genzgd  please let me know if I'm missing something here.