### PR TITLE
Fix issue that list_schemas always return 0 rows with http driver

### DIFF
--- a/dbt/adapters/clickhouse/connections.py
+++ b/dbt/adapters/clickhouse/connections.py
@@ -256,7 +256,7 @@ def _connect_http(credentials):
             send_receive_timeout=credentials.send_receive_timeout,
             client_name=f'cc-dbt-{dbt_version}',
             verify=credentials.verify,
-            query_limit=0,
+            query_limit=5000,
             session_id='dbt::' + str(uuid.uuid4()),
             **(credentials.custom_settings or {}),
         )


### PR DESCRIPTION
## Issue Description
When I run `dbt-clickhouse` [demo](https://clickhouse.com/docs/en/integrations/dbt/dbt-connecting), it work well in my macbook. But when I build it as a docker image, the `dbt run` command always failed in container with errors:
```
15:16:48.059063 [debug] [Thread-1  ]: Sending event: {'category': 'dbt', 'action': 'run_model', 'label': '39b0690b-9cab-41df-9d64-e0b5eb3470d0', 'context': [<snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7f05a3e435e0>]}
15:16:48.059637 [error] [Thread-1  ]: 1 of 1 ERROR creating incremental model imdb_dbt.actor_summary ................. [ERROR in 0.33s]
15:16:48.060385 [debug] [Thread-1  ]: Finished running node model.dataplat.actor_summary
15:16:48.062347 [debug] [MainThread]: Acquiring new clickhouse connection "master"
15:16:48.062723 [info ] [MainThread]:
15:16:48.063135 [info ] [MainThread]: Finished running 1 incremental model in 1.13s.
15:16:48.063536 [debug] [MainThread]: Connection 'master' was properly closed.
15:16:48.063838 [debug] [MainThread]: Connection 'model.dataplat.actor_summary' was properly closed.
15:16:48.069487 [info ] [MainThread]:
15:16:48.069855 [info ] [MainThread]: Completed with 1 error and 0 warnings:
15:16:48.070197 [info ] [MainThread]:
15:16:48.070456 [error] [MainThread]: Database Error in model actor_summary (models/actors/actor_summary.sql)
15:16:48.070721 [error] [MainThread]:   :HTTPDriver url http://<clickhouse_host>:8123 returned response code 500)
15:16:48.071053 [error] [MainThread]:    Code: 57. DB::Exception: Table imdb_dbt.actor_summary already exists. (TABLE_ALREADY_EXISTS) (version 22.6.3.35 (official build))
15:16:48.071350 [error] [MainThread]:   compiled SQL at target/run/dataplat/models/actors/actor_summary.sql
15:16:48.071587 [info ] [MainThread]:
15:16:48.071844 [info ] [MainThread]: Done. PASS=0 WARN=0 ERROR=1 SKIP=0 TOTAL=1
```
the `Dockerfile` like:
```
FROM python:3.8.1-slim-buster

# Set working directory
WORKDIR /app

# Install OS dependencies
RUN apt-get update && apt-get install -qq -y \
    git gcc build-essential libpq-dev --fix-missing --no-install-recommends \
    && apt-get clean

# Make sure we are using latest pip
RUN pip install --upgrade pip

# Create directory for dbt config
RUN mkdir -p /root/.dbt

# Copy requirements.txt
COPY requirements-dbt.txt requirements.txt

# Install dependencies
RUN pip install -r requirements.txt

# Copy dbt profile
COPY profiles.yml /root/.dbt/profiles.yml

# Copy source code
COPY ./dataplat /app

# Start the dbt RPC server
CMD ["dbt", "run"]
```

## Troubleshooting

I compare the logs in container and my laptop, I found dbt in container always try to create database:
```
15:16:47.418101 [debug] [ThreadPool]: clickhouse adapter: On create__imdb_dbt: /* {"app": "dbt", "dbt_version": "1.1.0", "profile_name": "clickhouse_imdb", "target_name": "dev", "connection_name": "create__imdb_dbt"} */
create database if not exists imdb_dbt

  ...
15:16:47.488070 [debug] [ThreadPool]: clickhouse adapter: SQL status: OK in 0.07 seconds
```
Then I check the clickhouse query_log, I found the query sql is different.

In docker container it be like:
```
/* {"app": "dbt", "dbt_version": "1.1.1", "profile_name": "clickhouse_imdb", "target_name": "dev", "connection_name": "list_schemas"} */

    select name from system.databases
  
 LIMIT 0
 FORMAT Native
```

In macos it be like:
```
/* {"app": "dbt", "dbt_version": "1.0.0", "profile_name": "normalize", "target_name": "prod", "connection_name": "list_schemas"} */

    select name from system.databases
```

Then I found the `query_limit`'s default value is `0` in  `connections.py`.

I change the value to `5000`, and it works now. But I still don't know why it works in macos before. :(