### PR TITLE
Dbt 1 3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,7 @@ on:  # yamllint disable-line rule:truthy
     branches-ignore:
       - '*_test'
       - '*_dev'
+      - '*_cloud'
 
 jobs:
   lint:

--- a/.github/workflows/test_cloud.yml
+++ b/.github/workflows/test_cloud.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 

--- a/.github/workflows/test_matrix.yml
+++ b/.github/workflows/test_matrix.yml
@@ -46,7 +46,7 @@ jobs:
              clickhouse/clickhouse-server:${{ matrix.clickhouse-version }}
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+### Release [1.3.0], 2022-10-30
+#### Improvement
+- Support dbt [1.3.0]  https://github.com/ClickHouse/dbt-clickhouse/issues/105
+  - Adds additional dbt 1.3.0 core tests
+  - Adds array utility macros ported from dbt-utils
+  - Does NOT add support for Python models (not implemented)
+  - Does NOT utilize default/standard incremental materialization macros (standard strategies do not work in ClickHouse)
+
+#### Bug Fix
+- Require exact match for relations.  ClickHouse databases and tables are all case sensitive, so all searches are now case sensitive.  Closes https://github.com/ClickHouse/dbt-clickhouse/issues/100 and https://github.com/ClickHouse/dbt-clickhouse/issues/110
+
+</br></br>
+
 ### Release [1.2.1], 2022-09-19
 #### Improvements
 - Support dbt 1.2.1  https://github.com/ClickHouse/dbt-clickhouse/issues/79

--- a/dbt/adapters/clickhouse/__version__.py
+++ b/dbt/adapters/clickhouse/__version__.py
@@ -1,1 +1,1 @@
-version = '1.2.2'
+version = '1.3.0'

--- a/dbt/adapters/clickhouse/column.py
+++ b/dbt/adapters/clickhouse/column.py
@@ -13,8 +13,8 @@ class ClickHouseColumn(Column):
     TYPE_LABELS = {
         'STRING': 'String',
         'TIMESTAMP': 'DateTime',
-        'FLOAT': 'Float64',
-        'INTEGER': 'Int64',
+        'FLOAT': 'Float32',
+        'INTEGER': 'Int32',
     }
     is_nullable: bool = False
     _brackets_regex = re.compile(r'^(Nullable|LowCardinality)\((.*)\)$')
@@ -109,7 +109,7 @@ class ClickHouseColumn(Column):
 
     @classmethod
     def numeric_type(cls, dtype: str, precision: Any, scale: Any) -> str:
-        return dtype
+        return f'Decimal({precision}, {scale})'
 
     def literal(self, value):
         return f'to{self.dtype}({value})'

--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -49,6 +49,7 @@ class ClickHouseAdapter(SQLAdapter):
     @classmethod
     def convert_number_type(cls, agate_table: agate.Table, col_idx: int) -> str:
         decimals = agate_table.aggregate(agate.MaxPrecision(col_idx))
+        # We match these type to the Column.TYPE_LABELS for consistency
         return 'Float32' if decimals else 'Int32'
 
     @classmethod

--- a/dbt/adapters/clickhouse/relation.py
+++ b/dbt/adapters/clickhouse/relation.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 import dbt.exceptions
 from dbt.adapters.base.relation import BaseRelation, Policy
@@ -38,3 +39,15 @@ class ClickHouseRelation(BaseRelation):
                 'include, but only one can be set'
             )
         return super().render()
+
+    def matches(
+        self,
+        database: Optional[str] = None,
+        schema: Optional[str] = None,
+        identifier: Optional[str] = None,
+    ):
+        if schema:
+            raise dbt.exceptions.RuntimeException(
+                f'Passed unexpected schema value {schema} to Relation.matches'
+            )
+        return self.database == database and self.identifier == identifier

--- a/dbt/include/clickhouse/macros/adapters.sql
+++ b/dbt/include/clickhouse/macros/adapters.sql
@@ -1,110 +1,3 @@
-{% macro engine_clause(label) %}
-  {%- set engine = config.get('engine', validator=validation.any[basestring]) -%}
-  {%- if engine is not none %}
-    {{ label }} = {{ engine }}
-  {%- else %}
-    {{ label }} = MergeTree()
-  {%- endif %}
-{%- endmacro -%}
-
-{% macro partition_cols(label) %}
-  {%- set cols = config.get('partition_by', validator=validation.any[list, basestring]) -%}
-  {%- if cols is not none %}
-    {%- if cols is string -%}
-      {%- set cols = [cols] -%}
-    {%- endif -%}
-    {{ label }} (
-    {%- for item in cols -%}
-      {{ item }}
-      {%- if not loop.last -%},{%- endif -%}
-    {%- endfor -%}
-    )
-  {%- endif %}
-{%- endmacro -%}
-
-{% macro primary_key_clause(label) %}
-  {%- set primary_key = config.get('primary_key', validator=validation.any[basestring]) -%}
-
-  {%- if primary_key is not none %}
-    {{ label }} {{ primary_key }}
-  {%- endif %}
-{%- endmacro -%}
-
-{% macro order_cols(label) %}
-  {%- set cols = config.get('order_by', validator=validation.any[list, basestring]) -%}
-  {%- set engine = config.get('engine', validator=validation.any[basestring]) -%}
-  {%- set supported = [
-    'HDFS',
-    'MaterializedPostgreSQL',
-    'S3',
-    'EmbeddedRocksDB',
-    'Hive'
-  ] -%}
-
-  {%- if engine is none or 'MergeTree' in engine or engine in supported %}
-    {%- if cols is not none %}
-      {%- if cols is string -%}
-        {%- set cols = [cols] -%}
-      {%- endif -%}
-      {{ label }} (
-      {%- for item in cols -%}
-        {{ item }}
-        {%- if not loop.last -%},{%- endif -%}
-      {%- endfor -%}
-      )
-    {%- else %}
-      {{ label }} (tuple())
-    {%- endif %}
-  {%- endif %}
-{%- endmacro -%}
-
-{% macro on_cluster_clause(label) %}
-  {% set on_cluster = adapter.get_clickhouse_cluster_name() %}
-  {%- if on_cluster is not none %}
-    {{ label }} {{ on_cluster }}
-  {%- endif %}
-{%- endmacro -%}
-
-{% macro clickhouse__create_table_as(temporary, relation, sql) -%}
-    {% set create_table = create_table_or_empty(temporary, relation, sql) %}
-    {% if adapter.is_before_version('22.7.1') -%}
-        {{ create_table }}
-    {%- else %}
-        {% call statement('create_table_empty') %}
-            {{ create_table }}
-        {% endcall %}
-        {{ clickhouse__insert_into(relation.include(database=False), sql) }}
-    {%- endif %}
-{%- endmacro %}
-
-{% macro create_table_or_empty(temporary, relation, sql) -%}
-    {%- set sql_header = config.get('sql_header', none) -%}
-
-    {{ sql_header if sql_header is not none }}
-
-    {% if temporary -%}
-        create temporary table {{ relation.name }}
-        engine Memory
-        {{ order_cols(label="order by") }}
-        {{ partition_cols(label="partition by") }}
-        {{ adapter.get_model_settings(model) }}
-    {%- else %}
-        create table {{ relation.include(database=False) }}
-        {{ on_cluster_clause(label="on cluster") }}
-        {{ engine_clause(label="engine") }}
-        {{ order_cols(label="order by") }}
-        {{ primary_key_clause(label="primary key") }}
-        {{ partition_cols(label="partition by") }}
-        {{ adapter.get_model_settings(model) }}
-        {% if not adapter.is_before_version('22.7.1') -%}
-            empty
-        {%- endif %}
-    {%- endif %}
-    as (
-        {{ sql }}
-    )
-{%- endmacro %}
-
 {% macro clickhouse__create_view_as(relation, sql) -%}
   {%- set sql_header = config.get('sql_header', none) -%}
 
@@ -221,16 +114,9 @@
   {% endcall %}
 {% endmacro %}
 
-{% macro clickhouse__insert_into(target_relation, sql) %}
-  {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
-  {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}
-
-  insert into {{ target_relation }} ({{ dest_cols_csv }})
-  {{ sql }}
-{%- endmacro %}
-
 {% macro exchange_tables_atomic(old_relation, target_relation) %}
   {%- call statement('exchange_tables_atomic') -%}
     EXCHANGE TABLES {{ old_relation }} AND {{ target_relation }}
   {% endcall %}
 {% endmacro %}
+

--- a/dbt/include/clickhouse/macros/materializations/incremental.sql
+++ b/dbt/include/clickhouse/macros/materializations/incremental.sql
@@ -49,6 +49,7 @@
 
     -- First create a temporary table with all of the new data
     {% set new_data_relation = existing_relation.incorporate(path={"identifier": model['name'] + '__dbt_new_data'}) %}
+    {{ drop_relation_if_exists(new_data_relation) }}
     {% call statement('create_new_data_temp') %}
         {{ get_create_table_as_sql(False, new_data_relation, sql) }}
     {% endcall %}

--- a/dbt/include/clickhouse/macros/materializations/seed.sql
+++ b/dbt/include/clickhouse/macros/materializations/seed.sql
@@ -16,13 +16,11 @@
   {%- set column_override = model['config'].get('column_types', {}) -%}
   {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}
 
-  {{ log}}
   {% set sql %}
     create table {{ this.render() }} (
       {%- for col_name in agate_table.column_names -%}
         {%- set inferred_type = adapter.convert_type(agate_table, loop.index0) -%}
         {%- set type = column_override.get(col_name, inferred_type) -%}
-        {{ log('SEED TYPE ' ~ type, True) }}
         {%- set column_name = (col_name | string) -%}
           {{ adapter.quote_seed_column(column_name, quote_seed_column) }} {{ type }} {%- if not loop.last -%}, {%- endif -%}
       {%- endfor -%}

--- a/dbt/include/clickhouse/macros/utils/utils.sql
+++ b/dbt/include/clickhouse/macros/utils/utils.sql
@@ -38,3 +38,22 @@
     'ClickHouse does not support the listagg function.  See the groupArray function instead')
     }}
 {% endmacro %}
+
+
+{% macro clickhouse__array_construct(inputs, data_type) -%}
+    {% if inputs|length > 0 %}
+    [ {{ inputs|join(' , ') }} ]
+    {% else %}
+    emptyArray{{data_type}}()
+    {% endif %}
+{%- endmacro %}
+
+
+{% macro clickhouse__array_append(array, new_element) -%}
+    arrayPushBack({{ array }}, {{ new_element }})
+{% endmacro %}
+
+
+{% macro clickhouse__array_concat(array_1, array_2) -%}
+   arrayConcat({{ array_1 }}, {{ array_2 }})
+{% endmacro %}

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,9 +1,9 @@
-dbt-core==1.2
+dbt-core==1.3
 clickhouse-connect>=0.2.7
 clickhouse-driver>=0.2.3
 pytest==7.0.0
 pytest-dotenv==0.5.2
-dbt-tests-adapter==1.2
+dbt-tests-adapter==1.3
 black==22.3.0
 isort==5.10.1
 mypy==0.960

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,7 +1,7 @@
 dbt-core==1.3
-clickhouse-connect>=0.2.7
+clickhouse-connect>=0.3.4
 clickhouse-driver>=0.2.3
-pytest==7.0.0
+pytest>=7.2.0
 pytest-dotenv==0.5.2
 dbt-tests-adapter==1.3
 black==22.3.0
@@ -10,3 +10,6 @@ mypy==0.960
 yamllint==1.26.3
 flake8==4.0.1
 types-requests==2.27.29
+agate~=1.6.3
+requests~=2.27.1
+setuptools~=65.3.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ package_name = 'dbt-clickhouse'
 package_version = _dbt_clickhouse_version()
 description = '''The Clickhouse plugin for dbt (data build tool)'''
 
-dbt_version = '1.2.1'
+dbt_version = '1.3.0'
 dbt_minor = '.'.join(dbt_version.split('.')[0:2])
 
 if not package_version.startswith(dbt_minor):

--- a/tests/integration/adapter/test_basic.py
+++ b/tests/integration/adapter/test_basic.py
@@ -64,7 +64,7 @@ class TestBaseAdapterMethod(BaseAdapterMethod):
     pass
 
 
-class TestMergeTreeTabelMaterializations(BaseSimpleMaterializations):
+class TestMergeTreeTableMaterialization(BaseSimpleMaterializations):
     @pytest.fixture(scope="class")
     def models(self):
         config_materialized_table = """
@@ -96,7 +96,7 @@ class TestMergeTreeTabelMaterializations(BaseSimpleMaterializations):
         assert result[0] == 10
 
 
-class TestInsertsOnlyIncrementalMaterializations(BaseIncremental):
+class TestInsertsOnlyIncrementalMaterialization(BaseIncremental):
     @pytest.fixture(scope="class")
     def models(self):
         config_materialized_incremental = """

--- a/tests/integration/adapter/test_basic.py
+++ b/tests/integration/adapter/test_basic.py
@@ -4,7 +4,7 @@ from dbt.tests.adapter.basic.test_adapter_methods import BaseAdapterMethod
 from dbt.tests.adapter.basic.test_base import BaseSimpleMaterializations
 from dbt.tests.adapter.basic.test_empty import BaseEmpty
 from dbt.tests.adapter.basic.test_generic_tests import BaseGenericTests
-from dbt.tests.adapter.basic.test_incremental import BaseIncremental
+from dbt.tests.adapter.basic.test_incremental import BaseIncremental, BaseIncrementalNotSchemaChange
 from dbt.tests.adapter.basic.test_singular_tests import BaseSingularTests
 from dbt.tests.adapter.basic.test_snapshot_check_cols import BaseSnapshotCheckCols
 from dbt.tests.adapter.basic.test_snapshot_timestamp import BaseSnapshotTimestamp
@@ -118,3 +118,21 @@ class TestCSVSeed:
         # seed command
         results = run_dbt(["seed"])
         assert len(results) == 2
+
+
+incremental_not_schema_change_sql = """
+{{ config(materialized="incremental", unique_key="user_id_current_time",on_schema_change="sync_all_columns") }}
+select
+    toString(1) || '-' || toString(now64()) as user_id_current_time,
+    {% if is_incremental() %}
+        'thisis18characters' as platform
+    {% else %}
+        'okthisis20characters' as platform
+    {% endif %}
+"""
+
+
+class TestIncrementalNotSchemaChange(BaseIncrementalNotSchemaChange):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"incremental_not_schema_change.sql": incremental_not_schema_change_sql}

--- a/tests/integration/adapter/test_concurrency.py
+++ b/tests/integration/adapter/test_concurrency.py
@@ -1,0 +1,33 @@
+from dbt.tests.adapter.concurrency.test_concurrency import BaseConcurrency, seeds__update_csv
+from dbt.tests.util import (
+    check_relations_equal,
+    check_table_does_not_exist,
+    rm_file,
+    run_dbt,
+    run_dbt_and_capture,
+    write_file,
+)
+
+
+class TestConcurrency(BaseConcurrency):
+    def test_clickhouse_concurrency(self, project):
+        run_dbt(["seed", "--select", "seed"])
+        results, output = run_dbt_and_capture(["run"], expect_pass=False)
+        self._validate_results(project, results, output)
+
+        rm_file(project.project_root, "seeds", "seed.csv")
+        write_file(seeds__update_csv, project.project_root, "seeds", "seed.csv")
+
+        results, output = run_dbt_and_capture(["run"], expect_pass=False)
+
+        self._validate_results(project, results, output)
+
+    def _validate_results(self, project, results, output):
+        assert len(results) == 7
+        check_relations_equal(project.adapter, ["seed", "view_model"])
+        check_relations_equal(project.adapter, ["seed", "dep"])
+        check_relations_equal(project.adapter, ["seed", "table_a"])
+        check_relations_equal(project.adapter, ["seed", "table_b"])
+        check_table_does_not_exist(project.adapter, "invalid")
+        check_table_does_not_exist(project.adapter, "skip")
+        assert "PASS=5 WARN=0 ERROR=1 SKIP=1 TOTAL=7" in output

--- a/tests/integration/adapter/test_upper_case.py
+++ b/tests/integration/adapter/test_upper_case.py
@@ -1,0 +1,64 @@
+import pytest
+from dbt.tests.util import run_dbt
+
+schema_upper_yml = """
+version: 2
+sources:
+  - name: seeds
+    schema: "{{ target.schema }}"
+    tables:
+      - name: seeds_upper
+        identifier: "{{ var('seed_name', 'seeds_upper') }}"
+"""
+
+
+seeds_upper_csv = """
+id,name,some_date
+1,Easton,1981-05-20T06:46:51
+2,Lillian,1978-09-03T18:10:33
+3,Jeremiah,1982-03-11T03:59:51
+4,Nolan,1976-05-06T20:21:35
+5,Hannah,1982-06-23T05:41:26
+6,Eleanor,1991-08-10T23:12:21
+7,Lily,1971-03-29T14:58:02
+8,Jonathan,1988-02-26T02:55:24
+9,Adrian,1994-02-09T13:14:23
+10,Nora,1976-03-01T16:51:39
+""".lstrip()
+
+
+class TestUpperCase:
+    @pytest.fixture(scope="class")
+    def models(self):
+        config_table_sql = """
+             {{ config(order_by='(some_date, id, name)', engine='MergeTree()', materialized='table',
+                        settings={'allow_nullable_key': 1}) }}
+
+            select * from {{ source('seeds', 'seeds_upper') }}
+           """
+        return {
+            "UPPER.sql": config_table_sql,
+            "schema.yml": schema_upper_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "name": "upper_test",
+        }
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "seeds_upper.csv": seeds_upper_csv,
+        }
+
+    def test_upper(self, project):
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+
+        results = run_dbt()
+        assert results[0].node.search_name == 'UPPER'
+
+        results = run_dbt()
+        assert results[0].node.search_name == 'UPPER'

--- a/tests/integration/adapter/utils/test_array.py
+++ b/tests/integration/adapter/utils/test_array.py
@@ -1,0 +1,36 @@
+import pytest
+from dbt.tests.adapter.utils.base_array_utils import BaseArrayUtils
+from dbt.tests.adapter.utils.fixture_array_append import models__array_append_actual_sql
+from dbt.tests.adapter.utils.fixture_array_concat import models__array_concat_actual_sql
+
+# Empty arrays are constructed with the DBT default "integer" which is an Int32.  Because ClickHouse will coerce
+# the arrays to the smallest possible type, we need to ensure that at least one of the members requires an Int32
+models__array_append_expected_sql = """
+select 1 as id, {{ array_construct([1,2,3,-77777777]) }} as array_col union all
+select 2 as id, {{ array_construct([4]) }} as array_col
+"""
+
+
+class TestArrayAppend(BaseArrayUtils):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "actual.sql": models__array_append_actual_sql,
+            "expected.sql": models__array_append_expected_sql,
+        }
+
+
+models__array_concat_expected_sql = """
+select 1 as id, {{ array_construct([1,2,3,4,5,-77777777]) }} as array_col union all
+select 2 as id, {{ array_construct([2]) }} as array_col union all
+select 3 as id, {{ array_construct([3]) }} as array_col
+"""
+
+
+class TestArrayConcat(BaseArrayUtils):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "actual.sql": models__array_concat_actual_sql,
+            "expected.sql": models__array_concat_expected_sql,
+        }

--- a/tests/integration/adapter/utils/test_datatypes.py
+++ b/tests/integration/adapter/utils/test_datatypes.py
@@ -1,0 +1,53 @@
+import pytest
+from dbt.tests.adapter.utils.data_types.base_data_type_macro import BaseDataTypeMacro
+from dbt.tests.adapter.utils.data_types.test_type_boolean import BaseTypeBoolean
+from dbt.tests.adapter.utils.data_types.test_type_float import BaseTypeFloat
+from dbt.tests.adapter.utils.data_types.test_type_int import BaseTypeInt
+from dbt.tests.adapter.utils.data_types.test_type_numeric import BaseTypeNumeric
+from dbt.tests.adapter.utils.data_types.test_type_string import BaseTypeString
+from dbt.tests.adapter.utils.data_types.test_type_timestamp import BaseTypeTimestamp
+
+models__bigint_expected_sql = """
+select -9223372036854775800 as bigint_col
+"""
+
+models__bigint_actual_sql = """
+select cast('-9223372036854775800' as {{ type_bigint() }}) as bigint_col
+"""
+
+
+class TestTypeBigInt(BaseDataTypeMacro):
+    # Using negative numbers instead since BIGINT on ClickHouse is signed, but the SELECT without a sign
+    # will be automatically cast to a UInt64
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "expected.sql": models__bigint_expected_sql,
+            "actual.sql": self.interpolate_macro_namespace(
+                models__bigint_actual_sql, "type_bigint"
+            ),
+        }
+
+
+class TestTypeBoolean(BaseTypeBoolean):
+    pass
+
+
+class TestTypeFloat(BaseTypeFloat):
+    pass
+
+
+class TestTypeInt(BaseTypeInt):
+    pass
+
+
+class TestTypeNumeric(BaseTypeNumeric):
+    pass
+
+
+class TestTypeString(BaseTypeString):
+    pass
+
+
+class TestTypeTimestamp(BaseTypeTimestamp):
+    pass

--- a/tests/integration/adapter/utils/test_unchanged.py
+++ b/tests/integration/adapter/utils/test_unchanged.py
@@ -1,7 +1,9 @@
 from dbt.tests.adapter.utils.test_any_value import BaseAnyValue
+from dbt.tests.adapter.utils.test_array_construct import BaseArrayConstruct
 from dbt.tests.adapter.utils.test_bool_or import BaseBoolOr
 from dbt.tests.adapter.utils.test_cast_bool_to_text import BaseCastBoolToText
 from dbt.tests.adapter.utils.test_concat import BaseConcat
+from dbt.tests.adapter.utils.test_current_timestamp import BaseCurrentTimestampNaive
 from dbt.tests.adapter.utils.test_date_trunc import BaseDateTrunc
 from dbt.tests.adapter.utils.test_escape_single_quotes import (
     BaseEscapeSingleQuotesBackslash,
@@ -74,4 +76,12 @@ class TestSafeCast(BaseSafeCast):
 
 
 class TestStringLiteral(BaseStringLiteral):
+    pass
+
+
+class TestCurrentTimestampNaive(BaseCurrentTimestampNaive):
+    pass
+
+
+class TestArrayConstruct(BaseArrayConstruct):
     pass


### PR DESCRIPTION
This turned out to be a fairly minor update.  Some additional tests to match the recommended DBT test-adapter and some array macros for utils are the main changes.

We don't have a plan right now to support Python Models (instead of SQL) and ClickHouse Incremental Materializations don't fit any of the "standard" models or SQL macros used by DBT core (this is because of the lack of unique primary keys and lightweight mutations), so 2 of the 3 tasks are not relevant to `dbt-clickhouse`