### PR TITLE
Release 1.3.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Upgrade Setuptools
         run: pip install --upgrade setuptools wheel

--- a/.github/workflows/test_matrix.yml
+++ b/.github/workflows/test_matrix.yml
@@ -28,6 +28,7 @@ jobs:
         clickhouse-version:
           - '22.3'
           - '22.8'
+          - '22.9'
           - latest
 
     steps:

--- a/dbt/adapters/clickhouse/__version__.py
+++ b/dbt/adapters/clickhouse/__version__.py
@@ -1,1 +1,1 @@
-version = '1.3.0'
+version = '1.3.1'

--- a/dbt/adapters/clickhouse/dbclient.py
+++ b/dbt/adapters/clickhouse/dbclient.py
@@ -134,7 +134,10 @@ class ChClientWrapper(ABC):
                 self.command('EXCHANGE TABLES {} AND {}'.format(*swap_tables))
                 return True
             except DBTDatabaseException as ex:
-                logger.info(f'ClickHouse server does not support exchange tables {ex}')
+                logger.info('ClickHouse server does not support the EXCHANGE TABLES command')
+                logger.info('This can be caused by an obsolete ClickHouse version or by running ClickHouse on')
+                logger.info('an operating system that does not support the low level renameat2() system call.')
+                logger.info('Some DBT materializations will be slower and not atomic as a result.')
             finally:
                 try:
                     for table in swap_tables:

--- a/dbt/adapters/clickhouse/dbclient.py
+++ b/dbt/adapters/clickhouse/dbclient.py
@@ -133,10 +133,14 @@ class ChClientWrapper(ABC):
             try:
                 self.command('EXCHANGE TABLES {} AND {}'.format(*swap_tables))
                 return True
-            except DBTDatabaseException as ex:
+            except DBTDatabaseException:
                 logger.info('ClickHouse server does not support the EXCHANGE TABLES command')
-                logger.info('This can be caused by an obsolete ClickHouse version or by running ClickHouse on')
-                logger.info('an operating system that does not support the low level renameat2() system call.')
+                logger.info(
+                    'This can be caused by an obsolete ClickHouse version or by running ClickHouse on'
+                )
+                logger.info(
+                    'an operating system that does not support the low level renameat2() system call.'
+                )
                 logger.info('Some DBT materializations will be slower and not atomic as a result.')
             finally:
                 try:

--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -349,7 +349,6 @@ def compare_versions(v1: str, v2: str) -> int:
             raise dbt.exceptions.RuntimeException(
                 "Version must consist of only numbers separated by '.'"
             )
-    # Versions are equal - return False
     return 0
 
 

--- a/dbt/include/clickhouse/macros/materializations/table.sql
+++ b/dbt/include/clickhouse/macros/materializations/table.sql
@@ -135,7 +135,7 @@
 
 {% macro clickhouse__create_table_as(temporary, relation, sql) -%}
     {% set create_table = create_table_or_empty(temporary, relation, sql) %}
-    {% if adapter.is_before_version('22.7.1') -%}
+    {% if adapter.is_before_version('22.7.1.2484') -%}
         {{ create_table }}
     {%- else %}
         {% call statement('create_table_empty') %}
@@ -164,7 +164,7 @@
         {{ primary_key_clause(label="primary key") }}
         {{ partition_cols(label="partition by") }}
         {{ adapter.get_model_settings(model) }}
-        {% if not adapter.is_before_version('22.7.1') -%}
+        {% if not adapter.is_before_version('22.7.1.2484') -%}
             empty
         {%- endif %}
     {%- endif %}

--- a/tests/integration/adapter/test_incremental.py
+++ b/tests/integration/adapter/test_incremental.py
@@ -1,0 +1,55 @@
+import pytest
+from dbt.tests.util import run_dbt
+
+uniq_schema = """
+version: 2
+
+models:
+  - name: "unique_source_one"
+    description: "Test table source"
+    columns:
+      - name: ts
+      - name: impid
+      - name: value1
+"""
+
+uniq_source_model = """
+{{config(
+        materialized='table',
+        engine='MergeTree()',
+        order_by=['ts'],
+        unique_key=['impid']
+    )
+}}
+SELECT now() - toIntervalHour(number) as ts, toInt32(number) as impid, concat('value', toString(number)) as value1
+  FROM numbers(100)
+"""
+
+uniq_incremental_model = """
+{{
+    config(
+        materialized='incremental',
+        engine='MergeTree()',
+        order_by=['ts'],
+        unique_key=['impid']
+    )
+}}
+select ts, impid from unique_source_one
+{% if is_incremental() %}
+where ts >= now() - toIntervalHour(1)
+{% endif %}
+"""
+
+
+class TestSimpleIncremental:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "unique_source_one.sql": uniq_source_model,
+            "unique_incremental_one.sql": uniq_incremental_model,
+            "schema.yml": uniq_schema,
+        }
+
+    def test_simple_incremental(self, project):
+        run_dbt(["run", "--select", "unique_source_one"])
+        run_dbt(["run", "--select", "unique_incremental_one"])

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 
 services:
   ch_server:
-    image: clickhouse/clickhouse-server:${DBT_TEST_CH_VERSION:-latest}
+    image: clickhouse/clickhouse-server:${DBT_CH_TEST_CH_VERSION:-latest}
     ports:
       - "10723:8123"
       - "10743:8443"


### PR DESCRIPTION
Fix info message when RENAME TABLE not available, fix edge case for CREATE TABLE AS ... EMPTY which is not available in some pre-stable 22.7.1 ClickHouse version.