### PR TITLE
In apply grants use role_name when user_name not available

### DIFF
--- a/dbt/include/clickhouse/macros/adapters/apply_grants.sql
+++ b/dbt/include/clickhouse/macros/adapters/apply_grants.sql
@@ -1,5 +1,5 @@
 {% macro clickhouse__get_show_grant_sql(relation) %}
-    SELECT access_type as privilege_type, user_name as grantee FROM system.grants WHERE table = '{{ relation.name }}'
+    SELECT access_type as privilege_type, COALESCE(user_name, role_name) as grantee FROM system.grants WHERE table = '{{ relation.name }}'
     AND database = '{{ relation.schema }}'
 {%- endmacro %}
 


### PR DESCRIPTION
Currently if the grant is given to a role, the `user_name` is null which leads to the below error when running `apply_grants`

```
'NoneType' object has no attribute 'casefold'
```