### PR TITLE
Update `on cluster` clause

### DIFF
--- a/dbt/include/clickhouse/macros/adapters.sql
+++ b/dbt/include/clickhouse/macros/adapters.sql
@@ -77,7 +77,7 @@
 
 {% macro clickhouse__truncate_relation(relation) -%}
   {% call statement('truncate_relation') -%}
-    truncate table {{ relation }}
+    truncate table {{ relation }} {{ on_cluster_clause(label="on cluster") }}
   {%- endcall %}
 {% endmacro %}
 
@@ -116,7 +116,7 @@
 
 {% macro exchange_tables_atomic(old_relation, target_relation) %}
   {%- call statement('exchange_tables_atomic') -%}
-    EXCHANGE TABLES {{ old_relation }} AND {{ target_relation }}
+    EXCHANGE TABLES {{ old_relation }} AND {{ target_relation }} {{ on_cluster_clause(label="on cluster") }}
   {% endcall %}
 {% endmacro %}
 

--- a/dbt/include/clickhouse/macros/adapters.sql
+++ b/dbt/include/clickhouse/macros/adapters.sql
@@ -60,18 +60,18 @@
   {% do return(load_result('get_columns_in_relation').table) %}
 {% endmacro %}
 
-{% macro clickhouse__drop_relation(relation) -%}
+{% macro clickhouse__drop_relation(relation, structure='table') -%}
   {% call statement('drop_relation', auto_begin=False) -%}
-    drop table if exists {{ relation }} {{ on_cluster_clause(label="on cluster") }}
+    drop {{ structure }} if exists {{ relation }} {{ on_cluster_clause(label="on cluster") }}
   {%- endcall %}
 {% endmacro %}
 
-{% macro clickhouse__rename_relation(from_relation, to_relation) -%}
+{% macro clickhouse__rename_relation(from_relation, to_relation, structure='table') -%}
   {% call statement('drop_relation') %}
-    drop table if exists {{ to_relation }} {{ on_cluster_clause(label="on cluster") }}
+    drop {{ structure }} if exists {{ to_relation }} {{ on_cluster_clause(label="on cluster") }}
   {% endcall %}
   {% call statement('rename_relation') %}
-    rename table {{ from_relation }} to {{ to_relation }} {{ on_cluster_clause(label="on cluster") }}
+    rename {{ structure }} {{ from_relation }} to {{ to_relation }} {{ on_cluster_clause(label="on cluster") }}
   {% endcall %}
 {% endmacro %}
 
@@ -114,9 +114,9 @@
   {% endcall %}
 {% endmacro %}
 
-{% macro exchange_tables_atomic(old_relation, target_relation) %}
+{% macro exchange_tables_atomic(old_relation, target_relation, structure='TABLES') %}
   {%- call statement('exchange_tables_atomic') -%}
-    EXCHANGE TABLES {{ old_relation }} AND {{ target_relation }} {{ on_cluster_clause(label="on cluster") }}
+    EXCHANGE {{ structure }} {{ old_relation }} AND {{ target_relation }} {{ on_cluster_clause(label="on cluster") }}
   {% endcall %}
 {% endmacro %}
 

--- a/dbt/include/clickhouse/macros/adapters/apply_grants.sql
+++ b/dbt/include/clickhouse/macros/adapters/apply_grants.sql
@@ -1,5 +1,5 @@
 {% macro clickhouse__get_show_grant_sql(relation) %}
-    SELECT access_type as privilege_type, user_name as grantee FROM system.grants WHERE table = '{{ relation.name }}'
+    SELECT access_type as privilege_type, COALESCE(user_name, role_name) as grantee FROM system.grants WHERE table = '{{ relation.name }}'
     AND database = '{{ relation.schema }}'
 {%- endmacro %}
 

--- a/dbt/include/clickhouse/macros/adapters/apply_grants.sql
+++ b/dbt/include/clickhouse/macros/adapters/apply_grants.sql
@@ -11,3 +11,11 @@
     {% endfor %}
 {% endmacro %}
 
+
+{%- macro clickhouse__get_grant_sql(relation, privilege, grantees) -%}
+    grant {{ on_cluster_clause(label="on cluster") }} {{ privilege }} on {{ relation }} to {{ grantees | join(', ') }}
+{%- endmacro -%}
+
+{%- macro clickhouse__get_revoke_sql(relation, privilege, grantees) -%}
+    revoke {{ on_cluster_clause(label="on cluster") }} {{ privilege }} on {{ relation }} from {{ grantees | join(', ') }}
+{%- endmacro -%}


### PR DESCRIPTION
Added cluster clause for DDLs, I believe this fixes #117 and also #95  as long as your engine uses the `{uuid}` macro for path.
see https://clickhouse.com/docs/en/guides/sre/keeper/clickhouse-keeper-uuid/#alternatives