### PR TITLE
Update requirements of `clickhouse-connect`

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,5 @@
 dbt-core~=1.3.2
-clickhouse-connect>=0.4.7
+clickhouse-connect==0.4.8
 clickhouse-driver>=0.2.3
 pytest>=7.2.0
 pytest-dotenv==0.5.2


### PR DESCRIPTION
Using version 0.5 or above breaks the `http` connection for clickhouse. Adding anything in `custom_settings` in profiles.yml leads to the following error when you run `dbt debug`

```
1 check failed:
dbt was unable to connect to the specified database.
The database returned the following error:
                                              
  >Database Error
  __init__() got an unexpected keyword argument 'max_insert_threads'
```
