### PR TITLE
Sync replica before exchange on `exchange_tables_atomic`

### DIFF
--- a/dbt/include/clickhouse/macros/adapters.sql
+++ b/dbt/include/clickhouse/macros/adapters.sql
@@ -109,6 +109,11 @@
 {% endmacro %}
 
 {% macro exchange_tables_atomic(old_relation, target_relation, obj_types='TABLES') %}
+
+  {%- if adapter.get_clickhouse_cluster_name() is not none and structure == 'TABLES' %}
+    {% do run_query("SYSTEM SYNC REPLICA "+target_relation.identifier) %}
+  {%- endif %}
+  
   {%- call statement('exchange_tables_atomic') -%}
     EXCHANGE {{ obj_types }} {{ old_relation }} AND {{ target_relation }} {{ on_cluster_clause()}}
   {% endcall %}

--- a/dbt/include/clickhouse/macros/adapters.sql
+++ b/dbt/include/clickhouse/macros/adapters.sql
@@ -110,7 +110,7 @@
 
 {% macro exchange_tables_atomic(old_relation, target_relation, obj_types='TABLES') %}
 
-  {%- if adapter.get_clickhouse_cluster_name() is not none and structure == 'TABLES' %}
+  {%- if adapter.get_clickhouse_cluster_name() is not none and obj_types == 'TABLES' %}
     {% do run_query("SYSTEM SYNC REPLICA "+target_relation.identifier) %}
   {%- endif %}
   


### PR DESCRIPTION
## Summary

Sync tables across replicas before exchange to preserve consistency. This was recommended to us by Altinity, we used it on our cluster without any degradation in performance.