### PR TITLE
Reduce number of MODIFY COMMENT queries count

### DIFF
--- a/dbt/include/clickhouse/macros/catalog.sql
+++ b/dbt/include/clickhouse/macros/catalog.sql
@@ -5,11 +5,11 @@
       columns.database as table_schema,
       columns.table as table_name,
       if(tables.engine not in ('MaterializedView', 'View'), 'table', 'view') as table_type,
-      tables.comment as table_comment,
+      nullIf(tables.comment, '') as table_comment,
       columns.name as column_name,
       columns.position as column_index,
       columns.type as column_type,
-      columns.comment as column_comment,
+      nullIf(columns.comment, '') as column_comment,
       null as table_owner
     from system.columns as columns
     join system.tables as tables on tables.database = columns.database and tables.name = columns.table

--- a/dbt/include/clickhouse/macros/persist_docs.sql
+++ b/dbt/include/clickhouse/macros/persist_docs.sql
@@ -14,14 +14,17 @@
   {%- set alter_comments = [] %}
 
   {%- if for_relation and config.persist_relation_docs() and model.description -%}
-    {% do alter_comments.append("modify comment '{comment}'".format(comment=model.description)) %}
+    {% set escaped_comment = clickhouse_escape_comment(model.description) %}
+    {% do alter_comments.append("modify comment {comment}".format(comment=escaped_comment)) %}
   {%- endif -%}
 
   {%- if for_columns and config.persist_column_docs() and model.columns -%}
-    {%- for column_name in model.columns -%}
+    {% set existing_columns = adapter.get_columns_in_relation(relation) | map(attribute="name") | list %}
+    {% for column_name in model.columns if (column_name in existing_columns) %}
       {%- set comment = model.columns[column_name]['description'] -%}
       {%- if comment %}
-        {% do alter_comments.append("comment column {column_name} '{comment}'".format(column_name=column_name, comment=comment)) %}
+        {% set escaped_comment = clickhouse_escape_comment(comment) %}
+        {% do alter_comments.append("comment column {column_name} {comment}".format(column_name=column_name, comment=escaped_comment)) %}
       {%- endif %}
     {%- endfor -%}
   {%- endif -%}
@@ -30,3 +33,22 @@
     {% do run_query(one_alter_relation(relation, alter_comments|join(', '))) %}
   {%- endif -%}
 {% endmacro %}
+
+{#
+  By using dollar-quoting like this, users can embed anything they want into their comments
+  (including nested dollar-quoting), as long as they do not use this exact dollar-quoting
+  label. It would be nice to just pick a new one but eventually you do have to give up.
+#}
+{% macro clickhouse_escape_comment(comment) -%}
+  {% if adapter.is_before_version('21.9.2.17') %}
+    {% do exceptions.raise_compiler_error('Unsupported ClickHouse version for using heredoc syntax') %}
+  {% endif %}
+  {% if comment is not string %}
+    {% do exceptions.raise_compiler_error('cannot escape a non-string: ' ~ comment) %}
+  {% endif %}
+  {%- set magic = '$dbt_comment_literal_block$' -%}
+  {%- if magic in comment -%}
+    {%- do exceptions.raise_compiler_error('The string ' ~ magic ~ ' is not allowed in comments.') -%}
+  {%- endif -%}
+  {{ magic }}{{ comment }}{{ magic }}
+{%- endmacro %}

--- a/dbt/include/clickhouse/macros/persist_docs.sql
+++ b/dbt/include/clickhouse/macros/persist_docs.sql
@@ -1,3 +1,7 @@
+{% macro one_alter_relation(relation, alter_comments) %}
+  alter table {{ relation }} {{ on_cluster_clause() }} {{ alter_comments }}
+{% endmacro %}
+
 {% macro one_alter_column_comment(relation, column_name, comment) %}
   alter table {{ relation }} {{ on_cluster_clause() }} comment column {{ column_name }} '{{ comment }}'
 {% endmacro %}
@@ -7,14 +11,22 @@
 {% endmacro %}
 
 {% macro clickhouse__persist_docs(relation, model, for_relation, for_columns) %}
+  {%- set alter_comments = [] %}
+
   {%- if for_relation and config.persist_relation_docs() and model.description -%}
-    {% do run_query(alter_relation_comment(relation, model.description)) %}
+    {% do alter_comments.append("modify comment '{comment}'".format(comment=model.description)) %}
   {%- endif -%}
 
   {%- if for_columns and config.persist_column_docs() and model.columns -%}
     {%- for column_name in model.columns -%}
       {%- set comment = model.columns[column_name]['description'] -%}
-      {% do run_query(one_alter_column_comment(relation, column_name, comment)) %}
+      {%- if comment %}
+        {% do alter_comments.append("comment column {column_name} '{comment}'".format(column_name=column_name, comment=comment)) %}
+      {%- endif %}
     {%- endfor -%}
+  {%- endif -%}
+
+  {%- if alter_comments | length > 0 -%}
+    {% do run_query(one_alter_relation(relation, alter_comments|join(', '))) %}
   {%- endif -%}
 {% endmacro %}

--- a/tests/integration/adapter/persist_docs/fixtures.py
+++ b/tests/integration/adapter/persist_docs/fixtures.py
@@ -1,0 +1,137 @@
+_MODELS__VIEW = """
+{{ config(materialized='view') }}
+select 2 as id, 'Bob' as name
+"""
+
+_MODELS__NO_DOCS_MODEL = """
+select 1 as id, 'Alice' as name
+"""
+
+_DOCS__MY_FUN_DOCS = """
+{% docs my_fun_doc %}
+name Column description "with double quotes"
+and with 'single  quotes' as welll as other;
+'''abc123'''
+reserved -- characters
+--
+/* comment */
+Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting
+
+{% enddocs %}
+"""
+
+_MODELS__TABLE = """
+{{ config(materialized='table') }}
+select 1 as id, 'Joe' as name
+"""
+
+
+_MODELS__MISSING_COLUMN = """
+{{ config(materialized='table') }}
+select 1 as id, 'Ed' as name
+"""
+
+_MODELS__MODEL_USING_QUOTE_UTIL = """
+select 1 as {{ adapter.quote("2id") }}
+"""
+
+_PROPERTIES__QUOTE_MODEL = """
+version: 2
+models:
+  - name: quote_model
+    description: "model to test column quotes and comments"
+    columns:
+      - name: 2id
+        description: "XXX My description"
+        quote: true
+"""
+
+_PROPERITES__SCHEMA_MISSING_COL = """
+version: 2
+models:
+  - name: missing_column
+    columns:
+      - name: id
+        description: "test id column description"
+      - name: column_that_does_not_exist
+        description: "comment that cannot be created"
+"""
+
+_PROPERTIES__SCHEMA_YML = """
+version: 2
+
+models:
+  - name: table_model
+    description: |
+      Table model description "with double quotes"
+      and with 'single  quotes' as welll as other;
+      '''abc123'''
+      reserved -- characters
+      --
+      /* comment */
+      Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting
+    columns:
+      - name: id
+        description: |
+          id Column description "with double quotes"
+          and with 'single  quotes' as welll as other;
+          '''abc123'''
+          reserved -- characters
+          --
+          /* comment */
+          Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting
+      - name: name
+        description: |
+          Some stuff here and then a call to
+          {{ doc('my_fun_doc')}}
+  - name: view_model
+    description: |
+      View model description "with double quotes"
+      and with 'single  quotes' as welll as other;
+      '''abc123'''
+      reserved -- characters
+      --
+      /* comment */
+      Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting
+    columns:
+      - name: id
+        description: |
+          id Column description "with double quotes"
+          and with 'single  quotes' as welll as other;
+          '''abc123'''
+          reserved -- characters
+          --
+          /* comment */
+          Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting
+
+seeds:
+  - name: seed
+    description: |
+      Seed model description "with double quotes"
+      and with 'single  quotes' as welll as other;
+      '''abc123'''
+      reserved -- characters
+      --
+      /* comment */
+      Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting
+    columns:
+      - name: id
+        description: |
+          id Column description "with double quotes"
+          and with 'single  quotes' as welll as other;
+          '''abc123'''
+          reserved -- characters
+          --
+          /* comment */
+          Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting
+      - name: name
+        description: |
+          Some stuff here and then a call to
+          {{ doc('my_fun_doc')}}
+"""
+
+
+_SEEDS__SEED = """id,name
+1,Alice
+2,Bob
+"""

--- a/tests/integration/adapter/persist_docs/test_persist_docs.py
+++ b/tests/integration/adapter/persist_docs/test_persist_docs.py
@@ -1,0 +1,212 @@
+import json
+import os
+
+import pytest
+from dbt.tests.util import run_dbt
+from fixtures import (
+    _DOCS__MY_FUN_DOCS,
+    _MODELS__MISSING_COLUMN,
+    _MODELS__MODEL_USING_QUOTE_UTIL,
+    _MODELS__NO_DOCS_MODEL,
+    _MODELS__TABLE,
+    _MODELS__VIEW,
+    _PROPERITES__SCHEMA_MISSING_COL,
+    _PROPERTIES__QUOTE_MODEL,
+    _PROPERTIES__SCHEMA_YML,
+    _SEEDS__SEED,
+)
+
+
+class BasePersistDocsBase:
+    @pytest.fixture(scope="class", autouse=True)
+    def setUp(self, project):
+        run_dbt(["seed"])
+        run_dbt()
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"seed.csv": _SEEDS__SEED}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "no_docs_model.sql": _MODELS__NO_DOCS_MODEL,
+            "table_model.sql": _MODELS__TABLE,
+            "view_model.sql": _MODELS__VIEW,
+        }
+
+    @pytest.fixture(scope="class")
+    def properties(self):
+        return {
+            "my_fun_docs.md": _DOCS__MY_FUN_DOCS,
+            "schema.yml": _PROPERTIES__SCHEMA_YML,
+        }
+
+    def _assert_common_comments(self, *comments):
+        for comment in comments:
+            assert '"with double quotes"' in comment
+            assert """'''abc123'''""" in comment
+            assert "\n" in comment
+            assert "Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting" in comment
+            assert "/* comment */" in comment
+            if os.name == "nt":
+                assert "--\r\n" in comment or "--\n" in comment
+            else:
+                assert "--\n" in comment
+
+    def _assert_has_table_comments(self, table_node):
+        table_comment = table_node["metadata"]["comment"]
+        assert table_comment.startswith("Table model description")
+
+        table_id_comment = table_node["columns"]["id"]["comment"]
+        assert table_id_comment.startswith("id Column description")
+
+        table_name_comment = table_node["columns"]["name"]["comment"]
+        assert table_name_comment.startswith("Some stuff here and then a call to")
+
+        self._assert_common_comments(table_comment, table_id_comment, table_name_comment)
+
+    def _assert_has_view_comments(
+        self, view_node, has_node_comments=True, has_column_comments=True
+    ):
+        view_comment = view_node["metadata"]["comment"]
+        if has_node_comments:
+            assert view_comment.startswith("View model description")
+            self._assert_common_comments(view_comment)
+        else:
+            assert view_comment is None
+
+        view_id_comment = view_node["columns"]["id"]["comment"]
+        if has_column_comments:
+            assert view_id_comment.startswith("id Column description")
+            self._assert_common_comments(view_id_comment)
+        else:
+            assert view_id_comment is None
+
+        view_name_comment = view_node["columns"]["name"]["comment"]
+        assert view_name_comment is None
+
+
+class BasePersistDocs(BasePersistDocsBase):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "test": {
+                    "+persist_docs": {
+                        "relation": True,
+                        "columns": True,
+                    },
+                }
+            }
+        }
+
+    def test_has_comments_pglike(self, project):
+        run_dbt(["docs", "generate"])
+        with open("target/catalog.json") as fp:
+            catalog_data = json.load(fp)
+        assert "nodes" in catalog_data
+        assert len(catalog_data["nodes"]) == 4
+        table_node = catalog_data["nodes"]["model.test.table_model"]
+        view_node = self._assert_has_table_comments(table_node)
+
+        view_node = catalog_data["nodes"]["model.test.view_model"]
+        self._assert_has_view_comments(view_node)
+
+        no_docs_node = catalog_data["nodes"]["model.test.no_docs_model"]
+        self._assert_has_view_comments(no_docs_node, False, False)
+
+
+class BasePersistDocsColumnMissing(BasePersistDocsBase):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "test": {
+                    "+persist_docs": {
+                        "columns": True,
+                    },
+                }
+            }
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"missing_column.sql": _MODELS__MISSING_COLUMN}
+
+    @pytest.fixture(scope="class")
+    def properties(self):
+        return {"schema.yml": _PROPERITES__SCHEMA_MISSING_COL}
+
+    def test_missing_column(self, project):
+        run_dbt(["docs", "generate"])
+        with open("target/catalog.json") as fp:
+            catalog_data = json.load(fp)
+        assert "nodes" in catalog_data
+
+        table_node = catalog_data["nodes"]["model.test.missing_column"]
+        table_id_comment = table_node["columns"]["id"]["comment"]
+        assert table_id_comment.startswith("test id column description")
+
+
+class BasePersistDocsCommentOnQuotedColumn:
+    """Covers edge case where column with comment must be quoted.
+    We set this using the `quote:` tag in the property file."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"quote_model.sql": _MODELS__MODEL_USING_QUOTE_UTIL}
+
+    @pytest.fixture(scope="class")
+    def properties(self):
+        return {"properties.yml": _PROPERTIES__QUOTE_MODEL}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "test": {
+                    "materialized": "table",
+                    "+persist_docs": {
+                        "relation": True,
+                        "columns": True,
+                    },
+                }
+            }
+        }
+
+    @pytest.fixture(scope="class")
+    def run_has_comments(self, project):
+        def fixt():
+            run_dbt()
+            run_dbt(["docs", "generate"])
+            with open("target/catalog.json") as fp:
+                catalog_data = json.load(fp)
+            assert "nodes" in catalog_data
+            assert len(catalog_data["nodes"]) == 1
+            column_node = catalog_data["nodes"]["model.test.quote_model"]
+            column_comment = column_node["columns"]["2id"]["comment"]
+            assert column_comment.startswith("XXX")
+
+        return fixt
+
+    def test_quoted_column_comments(self, run_has_comments):
+        run_has_comments()
+
+
+"""
+Code from tests is a copy from dbt-core/tests/adapter/dbt/tests/adapter/persist_docs
+It can be removed after upgrading to 1.5.0
+"""
+
+
+class TestPersistDocs(BasePersistDocs):
+    pass
+
+
+class TestPersistDocsColumnMissing(BasePersistDocsColumnMissing):
+    pass
+
+
+class TestPersistDocsCommentOnQuotedColumn(BasePersistDocsCommentOnQuotedColumn):
+    pass


### PR DESCRIPTION
## Summary
Call MODIFY COMMENT only if we really have description for column
Squash all alters for comments into single command to reduce number of SQL calls

Given this model
```yml
  - name: table
    description: Parsed events
    columns:
      - name: date
        description: Date when error occurred
      - name: timestamp
        description: timestamp from Kafka metadata
      - name: app_id
      - name: user_id
      - name: platform_id
```
Previous behaviour

```sql
alter table db.table modify comment 'Parsed events'
alter table db.table comment column date 'Date when error occurred'
alter table db.table comment column timestamp 'timestamp from Kafka metadata'
alter table db.table comment column platform_id ''
alter table db.table comment column app_id ''
alter table db.table comment column user_id ''
```

New behaviour
```sql
alter table db.table modify comment 'Parsed events', comment column date 'Date when error occurred', comment column timestamp 'timestamp from Kafka metadata'
```
