### PR TITLE
Fix database creation when cluster name is defined

### DIFF
--- a/dbt/adapters/clickhouse/dbclient.py
+++ b/dbt/adapters/clickhouse/dbclient.py
@@ -66,11 +66,7 @@ class ChClientWrapper(ABC):
         self._client = self._create_client(credentials)
         check_exchange = credentials.check_exchange and not credentials.cluster_mode
         try:
-            self._ensure_database(
-                credentials.database_engine, 
-                credentials.cluster_mode,
-                credentials.cluster
-            )
+            self._ensure_database(credentials.database_engine, credentials.cluster)
             self.server_version = self._server_version()
             self.has_lw_deletes, self.use_lw_deletes = self._check_lightweight_deletes(
                 credentials.use_lw_deletes
@@ -134,7 +130,7 @@ class ChClientWrapper(ABC):
             )
             return False, False
 
-    def _ensure_database(self, database_engine, cluster_mode, cluster_name) -> None:
+    def _ensure_database(self, database_engine, cluster_name) -> None:
         if not self.database:
             return
         check_db = f'EXISTS DATABASE {self.database}'
@@ -142,7 +138,7 @@ class ChClientWrapper(ABC):
             db_exists = self.command(check_db)
             if not db_exists:
                 engine_clause = f' ENGINE {database_engine} ' if database_engine else ''
-                cluster_clause = f' ON CLUSTER {cluster_name} ' if cluster_mode else ''
+                cluster_clause = f' ON CLUSTER {cluster_name} ' if cluster_name is not None else ''
                 self.command(f'CREATE DATABASE {self.database}{cluster_clause}{engine_clause}')
                 db_exists = self.command(check_db)
                 if not db_exists:

--- a/dbt/adapters/clickhouse/dbclient.py
+++ b/dbt/adapters/clickhouse/dbclient.py
@@ -66,7 +66,11 @@ class ChClientWrapper(ABC):
         self._client = self._create_client(credentials)
         check_exchange = credentials.check_exchange and not credentials.cluster_mode
         try:
-            self._ensure_database(credentials.database_engine)
+            self._ensure_database(
+                credentials.database_engine, 
+                credentials.cluster_mode,
+                credentials.cluster
+            )
             self.server_version = self._server_version()
             self.has_lw_deletes, self.use_lw_deletes = self._check_lightweight_deletes(
                 credentials.use_lw_deletes
@@ -130,7 +134,7 @@ class ChClientWrapper(ABC):
             )
             return False, False
 
-    def _ensure_database(self, database_engine) -> None:
+    def _ensure_database(self, database_engine, cluster_mode, cluster_name) -> None:
         if not self.database:
             return
         check_db = f'EXISTS DATABASE {self.database}'
@@ -138,7 +142,8 @@ class ChClientWrapper(ABC):
             db_exists = self.command(check_db)
             if not db_exists:
                 engine_clause = f' ENGINE {database_engine} ' if database_engine else ''
-                self.command(f'CREATE DATABASE {self.database}{engine_clause}')
+                cluster_clause = f' ON CLUSTER {cluster_name} ' if cluster_mode else ''
+                self.command(f'CREATE DATABASE {self.database}{cluster_clause}{engine_clause}')
                 db_exists = self.command(check_db)
                 if not db_exists:
                     raise FailedToConnectError(


### PR DESCRIPTION
## Summary
When running an on-premise ClickHouse cluster, dbt-clickhouse will attempt to create the database but doesn't yet take cluster mode into account. With this PR, I attempted to solve this issue by taking into account by checking if a cluster name is set in the credentials. If it is present, it adds it to the create database clause respecting the syntax from https://clickhouse.com/docs/en/sql-reference/statements/create/database.

I've tested it, but as the whole dbt-clickhouse repo doesn't have tests for cluster mode, I've not added integration tests here.

## Checklist
Delete items not relevant to your PR:
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
