### PR TITLE
Fix incompatible return type

### DIFF
--- a/dbt/adapters/clickhouse/connections.py
+++ b/dbt/adapters/clickhouse/connections.py
@@ -6,7 +6,7 @@ from typing import Any, Optional, Tuple
 import agate
 import dbt.exceptions
 from dbt.adapters.sql import SQLConnectionManager
-from dbt.contracts.connection import Connection
+from dbt.contracts.connection import AdapterResponse, Connection
 
 from dbt.adapters.clickhouse.dbclient import ChRetryableException, get_db_client
 from dbt.adapters.clickhouse.logger import logger
@@ -74,7 +74,7 @@ class ClickHouseConnectionManager(SQLConnectionManager):
 
     def execute(
         self, sql: str, auto_begin: bool = False, fetch: bool = False
-    ) -> Tuple[str, agate.Table]:
+    ) -> Tuple[AdapterResponse, agate.Table]:
         # Don't try to fetch result of clustered DDL responses, we don't know what to do with them
         if fetch and ddl_re.match(sql):
             fetch = False
@@ -98,7 +98,7 @@ class ClickHouseConnectionManager(SQLConnectionManager):
                 )
             else:
                 table = dbt.clients.agate_helper.empty_table()
-            return status, table
+            return AdapterResponse(_message=status), table
 
     def add_query(
         self,


### PR DESCRIPTION
## Summary

#161 

Change `ClickHouseConnectionManager.execute` return type
`Tuple[str, agate.Table]` -> `Tuple[AdapterResponse, agate.Table]`

examples:
- https://github.com/dbt-labs/dbt-redshift/blob/main/dbt/adapters/redshift/connections.py#L390
- https://github.com/dbt-labs/dbt-snowflake/blob/main/dbt/adapters/snowflake/connections.py#L447


