### PR TITLE
fix: incremental on cluster clause

### DIFF
--- a/dbt/include/clickhouse/macros/materializations/incremental.sql
+++ b/dbt/include/clickhouse/macros/materializations/incremental.sql
@@ -146,7 +146,12 @@
     -- use the table just created in the previous step because we don't want to override any updated rows with
     -- old rows when we insert the old data
     {% call statement('main') %}
-       create table {{ intermediate_relation }} as {{ new_data_relation }}
+        create table {{ intermediate_relation }}
+        {% set active_cluster = adapter.get_clickhouse_cluster_name() %}
+        {%- if active_cluster is not none %}
+        ON CLUSTER {{ active_cluster }}
+        {% endif %}
+        as {{ new_data_relation }}
     {% endcall %}
 
     -- Insert all the existing rows into the new temporary table, ignoring any rows that have keys in the "new data"


### PR DESCRIPTION
Missing `ON CLUSTER` clause when creating incremental temporary replicated table.

**Error;**
```bash
Code: 36. DB::Exception: Macro 'uuid' and empty arguments of ReplicatedMergeTree are supported only for ON CLUSTER queries with Atomic database engine. (BAD_ARGUMENTS) (version 23.6.2.18 (official build))
```

**Debug sql**
```sql
create table dbt.example__dbt_tmp as dbt.example__dbt_new_data
```

**Example config;**
```sql
{{ config(
    materialized="incremental",
    engine="ReplicatedMergeTree('/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}/{uuid}', '{replica}')",
    ...
) }}
```

## What this fix does

Changes
```sql
create table dbt.example__dbt_tmp as dbt.example__dbt_new_data
```

to

```sql
create table dbt.example__dbt_tmp ON CLUSTER '{cluster}' as dbt.example__dbt_new_data
```

If cluster has been set in config.