### PR TITLE
Add space to exchange_tables_atomic macro

### DIFF
--- a/dbt/include/clickhouse/macros/adapters.sql
+++ b/dbt/include/clickhouse/macros/adapters.sql
@@ -107,7 +107,7 @@
 {% macro exchange_tables_atomic(old_relation, target_relation, obj_types='TABLES') %}
 
   {%- if adapter.get_clickhouse_cluster_name() is not none and obj_types == 'TABLES' %}
-    {% do run_query("SYSTEM SYNC REPLICA " + on_cluster_clause() + target_relation.schema + '.' + target_relation.identifier) %}
+    {% do run_query("SYSTEM SYNC REPLICA " + on_cluster_clause() + ' ' + target_relation.schema + '.' + target_relation.identifier) %}
   {%- endif %}
   
   {%- call statement('exchange_tables_atomic') -%}

--- a/dbt/include/clickhouse/macros/adapters.sql
+++ b/dbt/include/clickhouse/macros/adapters.sql
@@ -107,7 +107,7 @@
 {% macro exchange_tables_atomic(old_relation, target_relation, obj_types='TABLES') %}
 
   {%- if adapter.get_clickhouse_cluster_name() is not none and obj_types == 'TABLES' %}
-    {% do run_query("SYSTEM SYNC REPLICA " + on_cluster_clause() + ' ' + target_relation.schema + '.' + target_relation.identifier) %}
+    {% do run_query("SYSTEM SYNC REPLICA " + on_cluster_clause() + target_relation.schema + '.' + target_relation.identifier) %}
   {%- endif %}
   
   {%- call statement('exchange_tables_atomic') -%}

--- a/dbt/include/clickhouse/macros/materializations/table.sql
+++ b/dbt/include/clickhouse/macros/materializations/table.sql
@@ -124,7 +124,8 @@
 {% macro on_cluster_clause(label) %}
   {% set active_cluster = adapter.get_clickhouse_cluster_name() %}
   {%- if active_cluster is not none %}
-    ON CLUSTER {{ active_cluster }}
+    {# Add trailing whitespace to avoid problems when this clause is not last #}
+    ON CLUSTER {{ active_cluster + ' ' }}
   {%- endif %}
 {%- endmacro -%}
 


### PR DESCRIPTION
This changes the SYSTEM SYNC REPLICA query to have a space between the ON CLUSTER clause and the table name.

Solves #167 