### PR TITLE
increase version to 1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Release [1.5.3], 2023-07-27
+#### Bug Fixes
+
+
 ### Release [1.4.4], 2023-07-19
 #### Bug Fixes
 - Fixed two logging/exception handling issues that would cause exception on startup or when handling some exceptions

--- a/dbt/adapters/clickhouse/__version__.py
+++ b/dbt/adapters/clickhouse/__version__.py
@@ -1,1 +1,1 @@
-version = '1.4.4'
+version = "1.5.3"

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,9 +1,9 @@
-dbt-core~=1.4.1
-clickhouse-connect>=0.5.24
-clickhouse-driver>=0.2.3
-pytest>=7.2.0
+dbt-core~=1.5.3
+clickhouse-connect>=0.6.8
+clickhouse-driver>=0.2.6
+pytest>=7.3.2
 pytest-dotenv==0.5.2
-dbt-tests-adapter~=1.4.1
+dbt-tests-adapter~=1.5.3
 black==22.3.0
 isort==5.10.1
 mypy==0.991

--- a/setup.py
+++ b/setup.py
@@ -6,32 +6,34 @@ import re
 from setuptools import find_namespace_packages, setup
 
 this_directory = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(this_directory, 'README.md')) as f:
+with open(os.path.join(this_directory, "README.md")) as f:
     long_description = f.read()
 
 
 # get this from a separate file
 def _dbt_clickhouse_version():
-    _version_path = os.path.join(this_directory, 'dbt', 'adapters', 'clickhouse', '__version__.py')
-    _version_pattern = r'''version\s*=\s*["'](.+)["']'''
+    _version_path = os.path.join(
+        this_directory, "dbt", "adapters", "clickhouse", "__version__.py"
+    )
+    _version_pattern = r"""version\s*=\s*["'](.+)["']"""
     with open(_version_path) as f:
         match = re.search(_version_pattern, f.read().strip())
         if match is None:
-            raise ValueError(f'invalid version at {_version_path}')
+            raise ValueError(f"invalid version at {_version_path}")
         return match.group(1)
 
 
-package_name = 'dbt-clickhouse'
+package_name = "dbt-clickhouse"
 package_version = _dbt_clickhouse_version()
-description = '''The Clickhouse plugin for dbt (data build tool)'''
+description = """The Clickhouse plugin for dbt (data build tool)"""
 
-dbt_version = '1.4.0'
-dbt_minor = '.'.join(dbt_version.split('.')[0:2])
+dbt_version = "1.5.3"
+dbt_minor = ".".join(dbt_version.split(".")[0:2])
 
 if not package_version.startswith(dbt_minor):
     raise ValueError(
-        f'Invalid setup.py: package_version={package_version} must start with '
-        f'dbt_version={dbt_minor}'
+        f"Invalid setup.py: package_version={package_version} must start with "
+        f"dbt_version={dbt_minor}"
     )
 
 
@@ -40,36 +42,36 @@ setup(
     version=package_version,
     description=description,
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    author='ClickHouse Inc.',
-    author_email='guy@clickhouse.com',
-    url='https://github.com/ClickHouse/dbt-clickhouse',
-    license='MIT',
-    packages=find_namespace_packages(include=['dbt', 'dbt.*']),
+    long_description_content_type="text/markdown",
+    author="ClickHouse Inc.",
+    author_email="guy@clickhouse.com",
+    url="https://github.com/ClickHouse/dbt-clickhouse",
+    license="MIT",
+    packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     package_data={
-        'dbt': [
-            'include/clickhouse/dbt_project.yml',
-            'include/clickhouse/macros/*.sql',
-            'include/clickhouse/macros/**/*.sql',
+        "dbt": [
+            "include/clickhouse/dbt_project.yml",
+            "include/clickhouse/macros/*.sql",
+            "include/clickhouse/macros/**/*.sql",
         ]
     },
     install_requires=[
-        f'dbt-core~={dbt_version}',
-        'clickhouse-connect>=0.5.24',
-        'clickhouse-driver>=0.2.3',
+        f"dbt-core~={dbt_version}",
+        "clickhouse-connect>=0.6.8",
+        "clickhouse-driver>=0.2.6",
     ],
     python_requires=">=3.7",
-    platforms='any',
+    platforms="any",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'License :: OSI Approved :: Apache Software License',
-        'Operating System :: Microsoft :: Windows',
-        'Operating System :: MacOS :: MacOS X',
-        'Operating System :: POSIX :: Linux',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: Microsoft :: Windows",
+        "Operating System :: MacOS :: MacOS X",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )


### PR DESCRIPTION
## Summary
Increase version to support dbt-core=1.5.3

## Checklist
- Unit test failed on timestamp. The rest passed
```
==================================================================== FAILURES ====================================================================
_____________________________________________ TestCurrentTimestampNaive.test_current_timestamp_type ______________________________________________ 

self = <test_unchanged.TestCurrentTimestampNaive object at 0x000002848D26CE10>
current_timestamp = datetime.datetime(2023, 7, 27, 4, 11, 59, tzinfo=<UTC>)

    def test_current_timestamp_type(self, current_timestamp):
>       assert is_naive(current_timestamp)
E       assert False
E        +  where False = is_naive(datetime.datetime(2023, 7, 27, 4, 11, 59, tzinfo=<UTC>))
```
