### PR TITLE
Lw delete set fix

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,11 +1,13 @@
 ---
 name: "PyPI Release"
 
+# yamllint disable-line rule:truthy
 on:
   push:
     tags:
       - 'v*'
   workflow_dispatch:
+
 
 jobs:
   publish:

--- a/.github/workflows/test_cloud.yml
+++ b/.github/workflows/test_cloud.yml
@@ -17,6 +17,7 @@ jobs:
       DBT_CH_TEST_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST }}
       DBT_CH_TEST_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD }}
       DBT_CH_TEST_CLUSTER_MODE: true
+      DBT_CH_TEST_CLOUD: true
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Release [1.4.6], 2023-07-27
+#### Bug fix
+- Lightweight deletes could fail in environments where the HTTP session was not preserved (such as clusters behind a non-sticky
+load balancer).  This has been fixed by sending the required settings with every request instead of relying on a SET statement.
+A similar approach has been used to persist the 'insert_distributed_sync' setting for Distributed table materializations.
+
 ### Release [1.4.5], 2023-07-27
 #### Improvement
 - Adds additional experimental support for Distributed table engine models and incremental materialization.  See the README for

--- a/dbt/adapters/clickhouse/__version__.py
+++ b/dbt/adapters/clickhouse/__version__.py
@@ -1,1 +1,1 @@
-version = '1.4.5'
+version = '1.4.6'

--- a/dbt/adapters/clickhouse/dbclient.py
+++ b/dbt/adapters/clickhouse/dbclient.py
@@ -7,6 +7,10 @@ from dbt.adapters.clickhouse.credentials import ClickHouseCredentials
 from dbt.adapters.clickhouse.logger import logger
 
 
+LW_DELETE_SETTING = 'allow_experimental_lightweight_delete'
+ND_MUTATION_SETTING = 'allow_nondeterministic_mutations'
+
+
 def get_db_client(credentials: ClickHouseCredentials):
     driver = credentials.driver
     port = credentials.port
@@ -108,27 +112,37 @@ class ChClientWrapper(ABC):
         pass
 
     def _check_lightweight_deletes(self, requested: bool):
-        lw_deletes = self.get_ch_setting('allow_experimental_lightweight_delete')
-        if lw_deletes is None:
+        lw_deletes = self.get_ch_setting(LW_DELETE_SETTING)
+        nd_mutations = self.get_ch_setting(ND_MUTATION_SETTING)
+        if lw_deletes is None or nd_mutations is None:
             if requested:
                 logger.warning(
                     'use_lw_deletes requested but are not available on this ClickHouse server'
                 )
             return False, False
-        lw_deletes = int(lw_deletes)
-        if lw_deletes == 1:
+        lw_deletes = int(lw_deletes) > 0
+        if not lw_deletes:
+            try:
+                self.command(f'SET {LW_DELETE_SETTING} = 1')
+                self._conn_settings[LW_DELETE_SETTING] = 1
+                lw_deletes = True
+            except DbtDatabaseError:
+                pass
+        nd_mutations = int(nd_mutations) > 0
+        if lw_deletes and not nd_mutations:
+            try:
+                self.command(f'SET {ND_MUTATION_SETTING} = 1')
+                self._conn_settings[ND_MUTATION_SETTING] = 1
+                nd_mutations = True
+            except DbtDatabaseError:
+                pass
+        if lw_deletes and nd_mutations:
             return True, requested
-        if not requested:
-            return False, False
-        try:
-            self.command('SET allow_experimental_lightweight_delete = 1')
-            self.command('SET allow_nondeterministic_mutations = 1')
-            return True, True
-        except DbtDatabaseError as ex:
+        if requested:
             logger.warning(
-                'use_lw_deletes requested but cannot enable on this ClickHouse server %s', str(ex)
+                'use_lw_deletes requested but cannot enable on this ClickHouse server'
             )
-            return False, False
+        return False, False
 
     def _ensure_database(self, database_engine, cluster_name) -> None:
         if not self.database:

--- a/tests/integration/adapter/persist_docs/test_persist_docs.py
+++ b/tests/integration/adapter/persist_docs/test_persist_docs.py
@@ -101,14 +101,16 @@ class BasePersistDocs(BasePersistDocsBase):
             }
         }
 
-    def test_has_comments_pglike(self, project):
+    def test_has_comments_pg_like(self):
+        if os.environ.get('DBT_CH_TEST_CLOUD', '').lower() in ('1', 'true', 'yes'):
+            pytest.skip('Not running comment test for cloud')
         run_dbt(["docs", "generate"])
         with open("target/catalog.json") as fp:
             catalog_data = json.load(fp)
         assert "nodes" in catalog_data
         assert len(catalog_data["nodes"]) == 4
         table_node = catalog_data["nodes"]["model.test.table_model"]
-        view_node = self._assert_has_table_comments(table_node)
+        self._assert_has_table_comments(table_node)
 
         view_node = catalog_data["nodes"]["model.test.view_model"]
         self._assert_has_view_comments(view_node)

--- a/tests/integration/adapter/test_comments.py
+++ b/tests/integration/adapter/test_comments.py
@@ -67,7 +67,7 @@ class TestBaseComment:
         ['table_comment', 'view_comment'],
     )
     def test_comment(self, project, model_name):
-        if '_cloud' in os.environ.get('GITHUB_REF', ''):
+        if os.environ.get('DBT_CH_TEST_CLOUD', '').lower() in ('1', 'true', 'yes'):
             pytest.skip('Not running comment test for cloud')
         run_dbt(["run"])
         run_dbt(["docs", "generate"])


### PR DESCRIPTION
## Summary
Fixes lightweight deletes by actively setting `allow_nondeterministic_mutations` at the query level instead of relying on SET statements.

