### PR TITLE
Resolve Change Relation Type error between Distributed and non-distributed Materializations

### DIFF
--- a/dbt/include/clickhouse/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/clickhouse/macros/materializations/incremental/incremental.sql
@@ -3,6 +3,7 @@
   {%- set existing_relation = load_cached_relation(this) -%}
   {%- set target_relation = this.incorporate(type='table') -%}
 
+  {%- set is_existing_valid = validate_relation_existence(existing_relation, on_cluster=False) -%}
   {%- set unique_key = config.get('unique_key') -%}
   {% if unique_key is not none and unique_key|length == 0 %}
     {% set unique_key = none %}
@@ -28,7 +29,7 @@
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
   {% set to_drop = [] %}
 
-  {% if existing_relation is none %}
+  {% if not is_existing_valid %}
     -- No existing table, simply create a new one
     {% call statement('main') %}
         {{ get_create_table_as_sql(False, target_relation, sql) }}

--- a/dbt/include/clickhouse/macros/materializations/view.sql
+++ b/dbt/include/clickhouse/macros/materializations/view.sql
@@ -10,7 +10,7 @@
     {%- set backup_relation_type = existing_relation.type -%}
     {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}
     {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}
-    {% if not existing_relation.can_exchange %}
+    {% if not existing_relation.can_exchange or existing_relation.can_on_cluster != target_relation.can_on_cluster %}
       {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}
       {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}
     {% endif %}
@@ -33,7 +33,7 @@
     {% call statement('main') -%}
       {{ get_create_view_as_sql(target_relation, sql) }}
     {%- endcall %}
-  {% elif existing_relation.can_exchange %}
+  {% elif existing_relation.can_exchange and existing_relation.can_on_cluster == backup_relation.can_on_cluster %}
     -- We can do an atomic exchange, so no need for an intermediate
     {% call statement('main') -%}
       {{ get_create_view_as_sql(backup_relation, sql) }}

--- a/tests/integration/adapter/test_changing_relation_type.py
+++ b/tests/integration/adapter/test_changing_relation_type.py
@@ -1,5 +1,37 @@
+import os
+
+from typing import List, Optional
+import pytest
+from dbt.tests.util import run_dbt
 from dbt.tests.adapter.relations.test_changing_relation_type import BaseChangeRelationTypeValidator
 
 
 class TestChangeRelationTypes(BaseChangeRelationTypeValidator):
     pass
+
+
+class TestChangeRelationTypesWithDistributedMaterializations(BaseChangeRelationTypeValidator):
+
+    # changing relation from distributed to non-distrubted should raise compilation error
+    # unless with a full-refresh flag
+    def _run_and_check_materialization_error(self, materialization, extra_args: Optional[List] = None):
+        run_args = ["run", '--vars', f'materialized: {materialization}']
+        if extra_args:
+            run_args.extend(extra_args)
+        results = run_dbt(run_args, expect_pass=False)
+        assert results[0].status == "error"
+        assert "Incompatible relation status" in results[0].message
+
+    @pytest.mark.skipif(
+        os.environ.get('DBT_CH_TEST_CLUSTER', '').strip() == '', reason='Not on a cluster'
+    )
+    def test_changing_materialization_changes_relation_type(self, project):
+        self._run_and_check_materialization('view')
+        self._run_and_check_materialization('distributed_table')
+        self._run_and_check_materialization('distributed_incremental')
+        self._run_and_check_materialization_error('table')
+        self._run_and_check_materialization('table', extra_args=['--full-refresh'])
+        self._run_and_check_materialization('distributed_incremental', extra_args=['--full-refresh'])
+        self._run_and_check_materialization_error('incremental')
+        self._run_and_check_materialization('incremental', extra_args=['--full-refresh'])
+        self._run_and_check_materialization('distributed_table', extra_args=['--full-refresh'])

--- a/tests/integration/adapter/test_changing_relation_type.py
+++ b/tests/integration/adapter/test_changing_relation_type.py
@@ -1,9 +1,9 @@
 import os
-
 from typing import List, Optional
+
 import pytest
-from dbt.tests.util import run_dbt
 from dbt.tests.adapter.relations.test_changing_relation_type import BaseChangeRelationTypeValidator
+from dbt.tests.util import run_dbt
 
 
 class TestChangeRelationTypes(BaseChangeRelationTypeValidator):
@@ -14,7 +14,9 @@ class TestChangeRelationTypesWithDistributedMaterializations(BaseChangeRelationT
 
     # changing relation from distributed to non-distrubted should raise compilation error
     # unless with a full-refresh flag
-    def _run_and_check_materialization_error(self, materialization, extra_args: Optional[List] = None):
+    def _run_and_check_materialization_error(
+        self, materialization, extra_args: Optional[List] = None
+    ):
         run_args = ["run", '--vars', f'materialized: {materialization}']
         if extra_args:
             run_args.extend(extra_args)
@@ -31,7 +33,9 @@ class TestChangeRelationTypesWithDistributedMaterializations(BaseChangeRelationT
         self._run_and_check_materialization('distributed_incremental')
         self._run_and_check_materialization_error('table')
         self._run_and_check_materialization('table', extra_args=['--full-refresh'])
-        self._run_and_check_materialization('distributed_incremental', extra_args=['--full-refresh'])
+        self._run_and_check_materialization(
+            'distributed_incremental', extra_args=['--full-refresh']
+        )
         self._run_and_check_materialization_error('incremental')
         self._run_and_check_materialization('incremental', extra_args=['--full-refresh'])
         self._run_and_check_materialization('distributed_table', extra_args=['--full-refresh'])


### PR DESCRIPTION
## Summary
resolve #205 
Changing relation type from non-distributed materialization to distributed materialization or otherwise has confusing error messages and `full-refresh` is not helpful.

## Changes
1.  Added a macro `validate_relation_existence`  to:
    1. raise an error when existing relation's on cluster status are not as expected (e.g. relation first created using table materialization then changed to distributed_table)
    2. drop existing relation when a `full-refresh` flag is provided
    3. drop existing relation when relation type is changed (view to table or otherwise) since view materialization is defaulted to be created on cluster
2. Added a test in `test_changing_relation_type.py`
3. Debug macro `test_changing_relation_type`, if the cluster has only one node, set is_on_cluster to true.

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG

