### PR TITLE
Fix creation of replicated tables when using legacy strategy and unique_key

### DIFF
--- a/dbt/include/clickhouse/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/clickhouse/macros/materializations/incremental/incremental.sql
@@ -162,7 +162,7 @@
       {{ create_distributed_local_table(distributed_intermediate_relation, intermediate_relation, existing_relation) }}
     {% else %}
       {% call statement('main') %}
-          create table {{ intermediate_relation }} as {{ new_data_relation }} {{ on_cluster_clause(existing_relation) }}
+          create table {{ intermediate_relation }} {{ on_cluster_clause(existing_relation) }} as {{ new_data_relation }}
       {% endcall %}
     {% endif %}
 


### PR DESCRIPTION
## Problem

Table creation fails in the situation where:
- you are **not** using distributed materializations
- you are using `ReplicatedMergeTree` table engines
- you are using `cluster_mode: true`
- you have defined a `unique_key` for a model
- you are using legacy incremental model strategy

## Cause

The cause is twofold:
1. `create table [table1] as [table2] on cluster [cluster]` is invalid SQL for ClickHouse (at least for OSS). The `on cluster [cluster]` clause is not supported for `create table .. as` statements.
2. When removing the `on_cluster_clause`, table creation fails on `Code: 36. DB::Exception: Received from localhost:9000. DB::Exception: Macro 'uuid' and empty arguments of ReplicatedMergeTree are supported only for ON CLUSTER queries with Atomic database engine. (BAD_ARGUMENTS)`.

So in this case, `on cluster` is both required and not supported at the same time.

## Solution

This PR changes `create table [table1] as [table2]` to `create table [table1] empty as ([sql for table1])`. This lets dbt supply ClickHouse with the SQL that was used to create `[table1]` for `[table2]`, instead of letting ClickHouse look at `[table2]` itself to copy the schema.

## Tests

All tests pass locally.