### PR TITLE
Adjust the wrapper parenthesis around the table materialization sql code

### DIFF
--- a/dbt/include/clickhouse/macros/materializations/table.sql
+++ b/dbt/include/clickhouse/macros/materializations/table.sql
@@ -153,7 +153,9 @@
         {{ order_cols(label="order by") }}
         {{ partition_cols(label="partition by") }}
         {{ adapter.get_model_settings(model) }}
-        as ( {{ sql }} )
+        as (
+          {{ sql }}
+        )
     {%- else %}
         create table {{ relation.include(database=False) }}
         {{ on_cluster_clause(relation)}}
@@ -171,7 +173,9 @@
           {%- if not adapter.is_before_version('22.7.1.2484') %}
             empty
           {%- endif %}
-           as ( {{ sql }} )
+          as (
+            {{ sql }}
+          )
         {%- endif %}
     {%- endif %}
 


### PR DESCRIPTION
## Summary
Due to a change in PR Release 1 5 0  the multiline code was consolidated into a single line. This cause an issue if we use it with SQLFluff and use the --noqa keyword or add any comment to the last line resulting a commented-out closing parenthesis. 

Code example:
Before the  original change code got compile like this : 
``` 
create table x.y
  engine = ReplicatedMergeTree
        order by (token_address,address)
        empty
    as (

          SELECT
              x,
              y,
              z
          FROM source
          settings optimize_aggregation_in_order=1 --noqa
    )
``` 
After the release code gets compile into the format below and resulting syntax error:
``` 
create table x.y
  engine = ReplicatedMergeTree
        order by (token_address,address)
        empty
    as (

          SELECT
              x,
              y,
              z
          FROM source
          settings optimize_aggregation_in_order=1 --noqa )
``` 

