### PR TITLE
Wrap columns_in_query query in select statement

### DIFF
--- a/dbt/adapters/clickhouse/httpclient.py
+++ b/dbt/adapters/clickhouse/httpclient.py
@@ -25,7 +25,7 @@ class ChHttpClient(ChClientWrapper):
 
     def columns_in_query(self, sql: str, **kwargs) -> List[ClickHouseColumn]:
         try:
-            query_result = self._client.query(f'{sql} LIMIT 0', **kwargs)
+            query_result = self._client.query(f'SELECT * FROM ({sql}) LIMIT 0', **kwargs)
             return [
                 ClickHouseColumn.create(name, ch_type.name)
                 for name, ch_type in zip(query_result.column_names, query_result.column_types)

--- a/dbt/adapters/clickhouse/httpclient.py
+++ b/dbt/adapters/clickhouse/httpclient.py
@@ -25,7 +25,7 @@ class ChHttpClient(ChClientWrapper):
 
     def columns_in_query(self, sql: str, **kwargs) -> List[ClickHouseColumn]:
         try:
-            query_result = self._client.query(f'SELECT * FROM ({sql}) LIMIT 0', **kwargs)
+            query_result = self._client.query(f"SELECT * FROM ({sql}) LIMIT 0", **kwargs)
             return [
                 ClickHouseColumn.create(name, ch_type.name)
                 for name, ch_type in zip(query_result.column_names, query_result.column_types)

--- a/dbt/adapters/clickhouse/nativeclient.py
+++ b/dbt/adapters/clickhouse/nativeclient.py
@@ -34,7 +34,7 @@ class ChNativeClient(ChClientWrapper):
 
     def columns_in_query(self, sql: str, **kwargs) -> List[ClickHouseColumn]:
         try:
-            _, columns = self._client.execute(f'{sql} LIMIT 0', with_column_types=True)
+            _, columns = self._client.execute(f'SELECT * FROM ({sql}) LIMIT 0', with_column_types=True)
             return [ClickHouseColumn.create(column[0], column[1]) for column in columns]
         except clickhouse_driver.errors.Error as ex:
             raise DbtDatabaseError(str(ex).strip()) from ex

--- a/dbt/adapters/clickhouse/nativeclient.py
+++ b/dbt/adapters/clickhouse/nativeclient.py
@@ -34,7 +34,9 @@ class ChNativeClient(ChClientWrapper):
 
     def columns_in_query(self, sql: str, **kwargs) -> List[ClickHouseColumn]:
         try:
-            _, columns = self._client.execute(f'SELECT * FROM ({sql}) LIMIT 0', with_column_types=True)
+            _, columns = self._client.execute(
+                f"SELECT * FROM ({sql}) LIMIT 0", with_column_types=True
+            )
             return [ClickHouseColumn.create(column[0], column[1]) for column in columns]
         except clickhouse_driver.errors.Error as ex:
             raise DbtDatabaseError(str(ex).strip()) from ex


### PR DESCRIPTION
## Summary
Appending `LIMIT 0` to queries that already have a LIMIT results in a syntax error:
```
... limit 10000 LIMIT 0 FORMAT JSON ...
>>> Code: 62. DB::Exception: Syntax error: failed at position 6358 ('LIMIT') (line 200, col 17): LIMIT 0
 FORMAT JSON.
 ```
This is resolved by wrapping the query inside a select statement and limiting this clause.