### PR TITLE
fix: use correct schema for MV target tables

### DIFF
--- a/dbt/include/clickhouse/macros/materializations/materialized_view.sql
+++ b/dbt/include/clickhouse/macros/materializations/materialized_view.sql
@@ -41,7 +41,7 @@
       {{ clickhouse__get_create_materialized_view_as_sql(target_relation, sql) }}
     {%- endcall %}
   {% elif existing_relation.can_exchange %}
-    {{ log('Replacing existing materialized view' + target_relation.name) }}
+    {{ log('Replacing existing materialized view ' + target_relation.name) }}
     {% call statement('drop existing materialized view') %}
       drop view if exists {{ mv_relation }} {{ cluster_clause }}
     {% endcall %}
@@ -50,10 +50,10 @@
     {%- endcall %}
     {% do exchange_tables_atomic(backup_relation, existing_relation) %}
     {% call statement('create new materialized view') %}
-      {{ clickhouse__create_mv_sql(mv_relation, existing_relation.name, cluster_clause, sql) }}
+      {{ clickhouse__create_mv_sql(mv_relation, existing_relation, cluster_clause, sql) }}
     {% endcall %}
   {% else %}
-    {{ log('Replacing existing materialized view' + target_relation.name) }}
+    {{ log('Replacing existing materialized view ' + target_relation.name) }}
     {{ clickhouse__replace_mv(target_relation, existing_relation, intermediate_relation, backup_relation, sql) }}
   {% endif %}
 


### PR DESCRIPTION
## Summary
The existing implementation of materialized views had one case where the target relation name was passed as a string of just the table name, instead of the full relation object. This meant that any custom schema would not be included in the final DDL statement, and the MV would break as it would try to write to a target table that didn't exist. This change passes the full relation object when getting the "create materialized view" SQL, which in turn provides the full path to the table in every case.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
