### PR TITLE
Bug/223 relationship test with limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Release [1.7.2], 2024-XX-XX
+#### Bug Fixes
+- A few tests with LIMIT clause were broken due to parsing error when having settings in the query ([issue](https://github.com/ClickHouse/dbt-clickhouse/issues/223)). We added a dedicated limit placer, that takes into account the settings section (using a comment flag `-- settings_section` within the query).
+
 ### Release [1.7.1], 2023-12-13
 #### Bug Fixes
 - Some models with LIMIT clauses were broken in recent releases.  This has been fixed.  Thanks to

--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -412,7 +412,14 @@ class ClickHouseAdapter(SQLAdapter):
         res = []
         for key in settings:
             res.append(f' {key}={settings[key]}')
-        return '' if len(res) == 0 else 'SETTINGS ' + ', '.join(res) + '\n'
+        if len(res) == 0:
+            return ''
+        else:
+            settings_str = 'SETTINGS ' + ', '.join(res) + '\n'
+            return f"""
+                        -- settings_section
+                        {settings_str}
+                        """
 
     @available
     def get_model_query_settings(self, model):
@@ -420,7 +427,15 @@ class ClickHouseAdapter(SQLAdapter):
         res = []
         for key in settings:
             res.append(f' {key}={settings[key]}')
-        return '' if len(res) == 0 else 'SETTINGS ' + ', '.join(res) + '\n'
+
+        if len(res) == 0:
+            return ''
+        else:
+            settings_str = 'SETTINGS ' + ', '.join(res) + '\n'
+            return f"""
+            -- settings_section
+            {settings_str}
+            """
 
     @available.parse_none
     def get_column_schema_from_query(self, sql: str, *_) -> List[ClickHouseColumn]:

--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -417,7 +417,7 @@ class ClickHouseAdapter(SQLAdapter):
         else:
             settings_str = 'SETTINGS ' + ', '.join(res) + '\n'
             return f"""
-                        -- settings_section
+                        -- end_of_sql
                         {settings_str}
                         """
 

--- a/dbt/include/clickhouse/macros/schema_tests/relationships.sql
+++ b/dbt/include/clickhouse/macros/schema_tests/relationships.sql
@@ -19,6 +19,7 @@ left join parent
     on child.from_field = parent.to_field
 
 where parent.to_field is null
+-- settings_section
 settings join_use_nulls = 1
 
 {% endmacro %}

--- a/dbt/include/clickhouse/macros/schema_tests/relationships.sql
+++ b/dbt/include/clickhouse/macros/schema_tests/relationships.sql
@@ -19,7 +19,7 @@ left join parent
     on child.from_field = parent.to_field
 
 where parent.to_field is null
--- settings_section
+-- end_of_sql
 settings join_use_nulls = 1
 
 {% endmacro %}

--- a/dbt/include/clickhouse/macros/utils/utils.sql
+++ b/dbt/include/clickhouse/macros/utils/utils.sql
@@ -15,12 +15,12 @@
 -- When multiple queries are nested, the limit will be attached to the outer query
 {% macro clickhouse__place_limit(query, limit) -%}
    {% if 'settings' in query.lower()%}
-        {% if '-- settings_section' not in query.lower()%}
-            {{exceptions.raise_compiler_error("-- settings_section must be set when using ClickHouse settings")}}
+        {% if '-- end_of_sql' not in query.lower()%}
+            {{exceptions.raise_compiler_error("-- end_of_sql must be set when using ClickHouse settings")}}
         {% endif %}
-        {% set split_by_settings_sections = query.split("-- settings_section")%}
+        {% set split_by_settings_sections = query.split("-- end_of_sql")%}
         {% set split_by_settings_sections_with_limit = split_by_settings_sections[-2] + "\n LIMIT " + limit|string  + "\n" %}
-        {% set query_with_limit = "-- settings_section".join(split_by_settings_sections[:-2] + [split_by_settings_sections_with_limit, split_by_settings_sections[-1]])%}
+        {% set query_with_limit = "-- end_of_sql".join(split_by_settings_sections[:-2] + [split_by_settings_sections_with_limit, split_by_settings_sections[-1]])%}
         {{query_with_limit}}
     {% else %}
     {{query}}

--- a/dbt/include/clickhouse/macros/utils/utils.sql
+++ b/dbt/include/clickhouse/macros/utils/utils.sql
@@ -1,3 +1,33 @@
+{% macro clickhouse__get_test_sql(main_sql, fail_calc, warn_if, error_if, limit) -%}
+    {% set main_sql_formatted = clickhouse__place_limit(main_sql, limit) if limit !=None else main_sql%}
+    select
+      {{ fail_calc }} as failures,
+      {{ fail_calc }} {{ warn_if }} as should_warn,
+      {{ fail_calc }} {{ error_if }} as should_error
+    from (
+      {{ main_sql_formatted }}
+    ) dbt_internal_test
+
+{%- endmacro %}
+
+
+-- This macro is designed to add a LIMIT clause to a ClickHouse SQL query while preserving any ClickHouse settings specified in the query.
+-- When multiple queries are nested, the limit will be attached to the outer query
+{% macro clickhouse__place_limit(query, limit) -%}
+   {% if 'settings' in query.lower()%}
+        {% if '-- settings_section' not in query.lower()%}
+            {{exceptions.raise_compiler_error("-- settings_section must be set when using ClickHouse settings")}}
+        {% endif %}
+        {% set split_by_settings_sections = query.split("-- settings_section")%}
+        {% set split_by_settings_sections_with_limit = split_by_settings_sections[-2] + "\n LIMIT " + limit|string  + "\n" %}
+        {% set query_with_limit = "-- settings_section".join(split_by_settings_sections[:-2] + [split_by_settings_sections_with_limit, split_by_settings_sections[-1]])%}
+        {{query_with_limit}}
+    {% else %}
+    {{query}}
+    {{"limit " ~ limit}}
+    {% endif %}
+{%- endmacro %}
+
 {% macro clickhouse__any_value(expression) -%}
     any({{ expression }})
 {%- endmacro %}


### PR DESCRIPTION
## Summary
As mentioned in issue #223, dbt fails to execute relationship tests when a limit clause is specified. The issue arises because the relationship test macro appends the join_use_nulls settings, and the limit is added at the end of the query (after the settings), causing a parsing error.

To address this limitation of adding a limit clause when the query includes settings, we developed a new macro that parses the query and inserts the limit just before the settings clause.

This is accomplished by introducing a flag within a comment, which is then used to parse the settings section accordingly.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG

