### PR TITLE
Add materialization macro for dictionaries

### DIFF
--- a/dbt/adapters/clickhouse/relation.py
+++ b/dbt/adapters/clickhouse/relation.py
@@ -3,7 +3,8 @@ from typing import Any, Dict, Optional, Type
 
 from dbt.adapters.base.relation import BaseRelation, Policy, Self
 from dbt.contracts.graph.nodes import ManifestNode, SourceDefinition
-from dbt.contracts.relation import HasQuoting, Path, RelationType
+from dbt.contracts.relation import HasQuoting, Path
+from dbt.dataclass_schema import StrEnum
 from dbt.exceptions import DbtRuntimeError
 from dbt.utils import deep_merge, merge
 
@@ -24,8 +25,19 @@ class ClickHouseIncludePolicy(Policy):
     identifier: bool = True
 
 
+class ClickHouseRelationType(StrEnum):
+    Table = "table"
+    View = "view"
+    CTE = "cte"
+    MaterializedView = "materialized_view"
+    External = "external"
+    Ephemeral = "ephemeral"
+    Dictionary = "dictionary"
+
+
 @dataclass(frozen=True, eq=False, repr=False)
 class ClickHouseRelation(BaseRelation):
+    type: Optional[ClickHouseRelationType] = None
     quote_policy: Policy = field(default_factory=lambda: ClickHouseQuotePolicy())
     include_policy: Policy = field(default_factory=lambda: ClickHouseIncludePolicy())
     quote_character: str = '`'
@@ -42,7 +54,7 @@ class ClickHouseRelation(BaseRelation):
 
     def derivative(self, suffix: str, relation_type: Optional[str] = None) -> BaseRelation:
         path = Path(schema=self.path.schema, database='', identifier=self.path.identifier + suffix)
-        derivative_type = RelationType[relation_type] if relation_type else self.type
+        derivative_type = ClickHouseRelationType[relation_type] if relation_type else self.type
         return ClickHouseRelation(type=derivative_type, path=path)
 
     def matches(

--- a/dbt/adapters/clickhouse/relation.py
+++ b/dbt/adapters/clickhouse/relation.py
@@ -54,7 +54,7 @@ class ClickHouseRelation(BaseRelation):
 
     def derivative(self, suffix: str, relation_type: Optional[str] = None) -> BaseRelation:
         path = Path(schema=self.path.schema, database='', identifier=self.path.identifier + suffix)
-        derivative_type = ClickHouseRelationType[relation_type] if relation_type else self.type
+        derivative_type = ClickHouseRelationType(relation_type) if relation_type else self.type
         return ClickHouseRelation(type=derivative_type, path=path)
 
     def matches(

--- a/dbt/include/clickhouse/macros/adapters.sql
+++ b/dbt/include/clickhouse/macros/adapters.sql
@@ -24,7 +24,11 @@
     select
       t.name as name,
       t.database as schema,
-      if(engine not in ('MaterializedView', 'View'), 'table', 'view') as type,
+      multiIf(
+        engine in ('MaterializedView', 'View'), 'view',
+        engine = 'Dictionary', 'dictionary',
+        'table'
+      ) as type,
       db.engine as db_engine,
       {%- if adapter.get_clickhouse_cluster_name() -%}
         count(distinct _shard_num) > 1  as  is_on_cluster

--- a/dbt/include/clickhouse/macros/materializations/dictionary.sql
+++ b/dbt/include/clickhouse/macros/materializations/dictionary.sql
@@ -1,0 +1,116 @@
+{%- materialization dictionary, adapter='clickhouse' -%}
+
+  {%- set existing_relation = load_cached_relation(this) -%}
+  {%- set target_relation = this.incorporate(type='dictionary') -%}
+  {%- set intermediate_relation = make_intermediate_relation(target_relation) -%}
+  {%- set existing_intermediate_relation = load_cached_relation(intermediate_relation) -%}
+  {%- set backup_relation_type = 'dictionary' if existing_relation is none else existing_relation.type -%}
+  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}
+  {%- set existing_backup_relation = load_cached_relation(backup_relation) -%}
+
+  {%- set grant_config = config.get('grants') -%}
+
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+  {{ drop_dictionary_if_exists(existing_backup_relation) }}
+  {{ drop_dictionary_if_exists(existing_intermediate_relation) }}
+
+
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  {# create our new dictionary #}
+  {% call statement('main') -%}
+    {{ clickhouse__get_create_dictionary_as_sql(intermediate_relation, sql) }}
+  {%- endcall %}
+
+  {# cleanup #}
+  {% if existing_relation is not none %}
+    {% set existing_relation = load_cached_relation(existing_relation) %}
+    {% if existing_relation is not none %}
+      {{ adapter.rename_relation(existing_relation, backup_relation) }}
+    {% endif %}
+  {% endif %}
+  {{ adapter.rename_relation(intermediate_relation, target_relation) }}
+
+  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
+  {% do persist_docs(target_relation, model) %}
+
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+  {{ adapter.commit() }}
+
+  {{ drop_dictionary_if_exists(backup_relation) }}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {{ return({'relations': [target_relation]}) }}
+
+{%- endmaterialization -%}
+
+
+{% macro clickhouse__get_create_dictionary_as_sql(relation, sql) %}
+  {%- set fields = config.get('fields') -%}
+  {%- set source_type = config.get('source_type') -%}
+
+  CREATE DICTIONARY {{ relation }} {{ on_cluster_clause(relation) }}
+  (
+  {%- for (name, data_type) in fields -%}
+    {{ name }} {{ data_type }}{%- if not loop.last -%},{%- endif -%}
+  {%- endfor -%}
+  )
+  {{ primary_key_clause(label="primary key") }}
+  SOURCE(
+    {%- if source_type == 'http' %}
+      {{ http_source() }}
+    {% else %}
+      {{ clickhouse_source(sql) }}
+    {% endif -%}
+  )
+  LAYOUT({{ config.get('layout') }})
+  LIFETIME({{ config.get('lifetime') }})
+{% endmacro %}
+
+
+{% macro http_source() %}
+  HTTP(URL '{{ config.get("url") }}' FORMAT '{{ config.get("format") }}')
+{% endmacro %}
+
+
+{% macro clickhouse_source(sql) %}
+  {%- set credentials = adapter.get_credentials() -%}
+  {%- set table = config.get('table') -%}
+  CLICKHOUSE(
+      user '{{ credentials.get("user") }}'
+      {% if credentials.get("password") != '' -%}
+      password '{{ credentials.get("password") }}'
+      {%- endif %}
+      {% if credentials.get("database") != '' -%}
+      db '{{ credentials.get("database") }}'
+      {%- endif %}
+      {% if credentials.get("host") != '' and credentials.get("host") != 'localhost' -%}
+      host '{{ credentials.get("host") }}'
+      {% if credentials.get("port") != '' -%}
+      port '{{ credentials.get("port") }}'
+      {%- endif %}
+      {%- endif %}
+      {%- if table is not none %}
+        table '{{ table }}'
+      {% else %}
+        query "{{ sql }}"
+      {% endif -%}
+  )
+{% endmacro %}
+
+
+{% macro drop_dictionary_if_exists(relation) %}
+  {% if relation.type != 'dictionary' %}
+    {{ log(relation ~ ' is not a dictionary; defaulting to drop_relation_if_exists') }}
+    {{ drop_relation_if_exists(relation) }}
+  {% else %}
+    {% call statement('drop_dictionary_if_exists') %}
+      drop dictionary if exists {{ relation }}
+    {% endcall %}
+  {% endif %}
+{% endmacro %}

--- a/dbt/include/clickhouse/macros/materializations/materialized_view.sql
+++ b/dbt/include/clickhouse/macros/materializations/materialized_view.sql
@@ -6,7 +6,7 @@
 {%- materialization materialized_view, adapter='clickhouse' -%}
 
   {%- set target_relation = this.incorporate(type='table') -%}
-  {%- set mv_relation = target_relation.derivative('_mv', 'MaterializedView') -%}
+  {%- set mv_relation = target_relation.derivative('_mv', 'materialized_view') -%}
   {%- set cluster_clause = on_cluster_clause(target_relation) -%}
 
   {# look for an existing relation for the target table and create backup relations if necessary #}
@@ -87,7 +87,7 @@
     {{ get_create_table_as_sql(False, relation, sql) }}
   {% endcall %}
   {%- set cluster_clause = on_cluster_clause(relation) -%}
-  {%- set mv_relation = relation.derivative('_mv', 'MaterializedView') -%}
+  {%- set mv_relation = relation.derivative('_mv', 'materialized_view') -%}
   {{ clickhouse__create_mv_sql(mv_relation, relation, cluster_clause, sql) }}
 {%- endmacro %}
 
@@ -102,7 +102,7 @@
 {% macro clickhouse__replace_mv(target_relation, existing_relation, intermediate_relation, backup_relation, sql) %}
   {# drop existing materialized view while we recreate the target table #}
   {%- set cluster_clause = on_cluster_clause(target_relation) -%}
-  {%- set mv_relation = target_relation.derivative('_mv', 'MaterializedView') -%}
+  {%- set mv_relation = target_relation.derivative('_mv', 'materialized_view') -%}
   {% call statement('drop existing mv') -%}
     drop view if exists {{ mv_relation }} {{ cluster_clause }}
   {%- endcall %}

--- a/tests/integration/adapter/dictionary/test_dictionary.py
+++ b/tests/integration/adapter/dictionary/test_dictionary.py
@@ -1,0 +1,195 @@
+"""
+test dictionary support in dbt-clickhouse
+"""
+
+import json
+import os
+
+import pytest
+from dbt.tests.util import run_dbt
+
+testing_s3 = os.environ.get('DBT_CH_TEST_INCLUDE_S3', '').lower() in ('1', 'true', 'yes')
+
+
+PEOPLE_SEED_CSV = """
+id,name,age,department
+1231,Dade,33,engineering
+6666,Ksenia,48,engineering
+8888,Kate,50,engineering
+""".lstrip()
+
+# This model is parameterized, in a way, by the "run_type" dbt project variable
+# This is to be able to switch between different model definitions within
+# the same test run and allow us to test the evolution of a materialized view
+HACKERS_MODEL = """
+{{ config(
+       materialized='dictionary',
+       fields=[
+           ('id', 'Int32'),
+           ('name', 'String'),
+           ('hacker_alias', 'String')
+       ],
+       primary_key='id',
+       layout='COMPLEX_KEY_HASHED()',
+       lifetime='1',
+       source_type='clickhouse',
+) }}
+
+{% if var('run_type', '') == '' %}
+select
+    id,
+    name,
+    case
+        when name like 'Dade' then 'crash_override'
+        when name like 'Kate' then 'acid burn'
+        when name like 'Eugene' then 'the plague'
+        else 'N/A'
+    end as hacker_alias
+from {{ source('raw', 'people') }}
+
+{% else %}
+
+select
+    id,
+    name,
+    case
+        -- Dade wasn't always known as 'crash override'!
+        when name like 'Dade' and age = 11 then 'zero cool'
+        when name like 'Dade' and age != 11 then 'crash override'
+        when name like 'Kate' then 'acid burn'
+        when name like 'Eugene' then 'the plague'
+        else 'N/A'
+    end as hacker_alias
+from {{ source('raw', 'people') }}
+{% endif %}
+"""
+
+
+TAXI_ZONE_DICTIONARY = """
+{{ config(
+       materialized='dictionary',
+       fields=[
+           ('LocationID', 'UInt16 DEFAULT 0'),
+           ('Borough', 'String'),
+           ('Zone', 'String'),
+           ('service_zone', 'String'),
+       ],
+       primary_key='LocationID',
+       layout='HASHED()',
+       lifetime='MIN 0 MAX 0',
+       source_type='http',
+       url='https://datasets-documentation.s3.eu-west-3.amazonaws.com/nyc-taxi/taxi_zone_lookup.csv',
+       format='CSVWithNames'
+) }}
+
+select 1
+"""
+
+
+PEOPLE_DICT_MODEL = """
+{{ config(
+       materialized='dictionary',
+       fields=[
+           ('id', 'Int32'),
+           ('name', 'String'),
+       ],
+       primary_key='id',
+       layout='HASHED()',
+       lifetime='1',
+       source_type='clickhouse',
+       table='people'
+) }}
+
+select 1
+"""
+
+
+SEED_SCHEMA_YML = """
+version: 2
+
+sources:
+  - name: raw
+    schema: "{{ target.schema }}"
+    tables:
+      - name: people
+"""
+
+
+class TestQueryDictionary:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "people.csv": PEOPLE_SEED_CSV,
+            "schema.yml": SEED_SCHEMA_YML,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "hackers.sql": HACKERS_MODEL,
+        }
+
+    def test_create_and_update(self, project):
+        run_dbt(["seed"])
+
+        result = project.run_sql("DESCRIBE TABLE people", fetch="all")
+        assert result[0][1] == "Int32"
+
+        run_dbt()
+        result = project.run_sql("select count(distinct id) from hackers", fetch="all")
+        assert result[0][0] == 3
+
+        # insert some data and make sure it reaches the target dictionary
+        project.run_sql(
+            f"""
+        insert into people ("id", "name", "age", "department")
+            values (1232,'Dade',11,'engineering'), (9999,'Eugene',40,'malware');
+        """
+        )
+        # force the dictionary to be rebuilt to include the new records in `people`
+        project.run_sql("system reload dictionary hackers")
+        result = project.run_sql("select count(distinct id) from hackers", fetch="all")
+        assert result[0][0] == 5
+
+        # re-run dbt but this time with the new MV SQL
+        run_vars = {"run_type": "extended_schema"}
+        run_dbt(["run", "--vars", json.dumps(run_vars)])
+        results = project.run_sql("select distinct hacker_alias from hackers", fetch="all")
+        names = set(i[0] for i in results)
+        assert names == set(["zero cool", "crash override", "acid burn", "the plague", "N/A"])
+
+
+class TestTableDictionary:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "people.csv": PEOPLE_SEED_CSV,
+            "schema.yml": SEED_SCHEMA_YML,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"people_dict.sql": PEOPLE_DICT_MODEL}
+
+    def test_create(self, project):
+        run_dbt(["seed"])
+        run_dbt()
+
+        results = project.run_sql("select distinct name from people_dict", fetch="all")
+        names = set(i[0] for i in results)
+        assert names == set(["Dade", "Kate", "Ksenia"])
+
+
+class TestHttpDictionary:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"taxi_zone_dictionary.sql": TAXI_ZONE_DICTIONARY}
+
+    @pytest.mark.skipif(not testing_s3, reason='Testing S3 disabled')
+    def test_create(self, project):
+        run_dbt()
+
+        results = project.run_sql(
+            "select count(distinct LocationID) from taxi_zone_dictionary", fetch="all"
+        )
+        assert results[0][0] == 265

--- a/tests/integration/adapter/dictionary/test_dictionary.py
+++ b/tests/integration/adapter/dictionary/test_dictionary.py
@@ -141,7 +141,7 @@ class TestQueryDictionary:
 
         # insert some data and make sure it reaches the target dictionary
         project.run_sql(
-            f"""
+            """
         insert into people ("id", "name", "age", "department")
             values (1232,'Dade',11,'engineering'), (9999,'Eugene',40,'malware');
         """


### PR DESCRIPTION
## Summary
Adds a materialization macro to support materializing models as [dictionaries](https://clickhouse.com/docs/en/sql-reference/dictionaries). Tests are included for query-, table-, and HTTP-based dictionaries. These tests also include examples of how to configure models to be materialized as dictionaries.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG