### PR TITLE
Fix model settings to use a custom materialization

### DIFF
--- a/dbt/adapters/clickhouse/dbclient.py
+++ b/dbt/adapters/clickhouse/dbclient.py
@@ -150,7 +150,8 @@ class ChClientWrapper(ABC):
         pass
 
     def update_model_settings(self, model_settings: Dict[str, str], materialization_type: str):
-        model_settings_to_add = copy.deepcopy(self._model_settings[materialization_type])
+        settings = self._model_settings.get(materialization_type, {})
+        model_settings_to_add = copy.deepcopy(settings)
         model_settings_to_add.update(self._model_settings['general'])
         for key, value in model_settings_to_add.items():
             if key not in model_settings:


### PR DESCRIPTION
If using a custom materialization, an error occurs

```
  File "/Users/silent/.pyenv/versions/dbt-pipelines/lib/python3.11/site-packages/dbt/adapters/clickhouse/impl.py", line 412, in get_model_settings
    conn.handle.update_model_settings(settings, materialization_type)
  File "/Users/silent/.pyenv/versions/dbt-pipelines/lib/python3.11/site-packages/dbt/adapters/clickhouse/dbclient.py", line 153, in update_model_settings
    model_settings_to_add = copy.deepcopy(self._model_settings[materialization_type])
                                          ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'NAME_MAT'
```
