### PR TITLE
fix(clients): syntax error when retrieving query columns

### DIFF
--- a/dbt/adapters/clickhouse/httpclient.py
+++ b/dbt/adapters/clickhouse/httpclient.py
@@ -25,7 +25,12 @@ class ChHttpClient(ChClientWrapper):
 
     def columns_in_query(self, sql: str, **kwargs) -> List[ClickHouseColumn]:
         try:
-            query_result = self._client.query(f"SELECT * FROM ({sql}) LIMIT 0", **kwargs)
+            query_result = self._client.query(
+                f"SELECT * FROM ( \n"
+                f"{sql} \n"
+                f") LIMIT 0",
+                **kwargs,
+            )
             return [
                 ClickHouseColumn.create(name, ch_type.name)
                 for name, ch_type in zip(query_result.column_names, query_result.column_types)

--- a/dbt/adapters/clickhouse/nativeclient.py
+++ b/dbt/adapters/clickhouse/nativeclient.py
@@ -35,7 +35,10 @@ class ChNativeClient(ChClientWrapper):
     def columns_in_query(self, sql: str, **kwargs) -> List[ClickHouseColumn]:
         try:
             _, columns = self._client.execute(
-                f"SELECT * FROM ({sql}) LIMIT 0", with_column_types=True
+                f"SELECT * FROM ( \n"
+                f"{sql} \n"
+                f") LIMIT 0",
+                with_column_types=True,
             )
             return [ClickHouseColumn.create(column[0], column[1]) for column in columns]
         except clickhouse_driver.errors.Error as ex:


### PR DESCRIPTION

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
