### PR TITLE
fix: add support for dictionary table engine

### DIFF
--- a/dbt/include/clickhouse/macros/materializations/table.sql
+++ b/dbt/include/clickhouse/macros/materializations/table.sql
@@ -135,7 +135,7 @@
 {% macro clickhouse__create_table_as(temporary, relation, sql) -%}
     {% set has_contract = config.get('contract').enforced %}
     {% set create_table = create_table_or_empty(temporary, relation, sql, has_contract) %}
-    {% if adapter.is_before_version('22.7.1.2484') -%}
+    {% if adapter.is_before_version('22.7.1.2484') or 'Dictionary' in config.get('engine', '') -%}
         {{ create_table }}
     {%- else %}
         {% call statement('create_table_empty') %}


### PR DESCRIPTION
## Summary
This PR fixes an issue with the [dictionary table engine](https://clickhouse.com/docs/en/engines/table-engines/special/dictionary) that when trying to add data to the dictionaries it will fail as Dictionary backed tables doesn't support writes.

## Testing instructions:

1. Create a dictionary:
```sql
{{
    config(
        materialized="dictionary",
        fields=[
            ...
        ],
        primary_key="...",
        layout="COMPLEX_KEY_HASHED()",
        lifetime="120",
        source_type="clickhouse",
    )
}}

select ... from ...
```

2. Create a table from that dictionary:

```sql
{{
    config(
        materialized="table",
        engine=get_engine('Dictionary(database.dictionary_name)'),
    )
}}
select * from {{ ref("model_name") }}
```

3. Make sure to enable `allow_automatic_deduplication` in your `profile`.
4. Run DBT and verify that the table is created

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
