### PR TITLE
feat: allow to add connection overrides for dictionaries

### DIFF
--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -458,17 +458,24 @@ class ClickHouseAdapter(SQLAdapter):
         return [{'name': column.name, 'data_type': column.dtype} for column in columns]
 
     @available
-    def get_credentials(self) -> Dict:
+    def get_credentials(self, connection_overrides) -> Dict:
         conn = self.connections.get_if_exists()
         if conn is None or conn.credentials is None:
             return dict()
-        return {
+        credentials = {
             'user': conn.credentials.user,
             'password': conn.credentials.password,
             'database': conn.credentials.database,
             'host': conn.credentials.host,
             'port': conn.credentials.port,
         }
+        credentials.update(connection_overrides)
+
+        for key in connection_overrides.keys():
+            if not credentials[key]:
+                credentials.pop(key)
+
+        return credentials
 
     @classmethod
     def render_raw_columns_constraints(cls, raw_columns: Dict[str, Dict[str, Any]]) -> List:

--- a/dbt/include/clickhouse/macros/materializations/dictionary.sql
+++ b/dbt/include/clickhouse/macros/materializations/dictionary.sql
@@ -79,7 +79,7 @@
 
 
 {% macro clickhouse_source(sql) %}
-  {%- set credentials = adapter.get_credentials() -%}
+  {%- set credentials = adapter.get_credentials(config.get("connection_overrides", {})) -%}
   {%- set table = config.get('table') -%}
   CLICKHOUSE(
       user '{{ credentials.get("user") }}'


### PR DESCRIPTION
## Summary
This PR fixed an issue in which ClickHouse was using the configured host to load the dictionary, however, this would fail if it was running on Docker and would be slower if it was using a URL to connect to ClickHouse. It implements a new config for the dictionary model allowing people to override connection params.

### Before
`SOURCE(CLICKHOUSE(USER 'ch_admin' PASSWORD '[HIDDEN]' HOST 'clickhouse' PORT '8123' QUERY ...)`

### After
`SOURCE(CLICKHOUSE(USER 'ch_admin' PASSWORD '[HIDDEN]' QUERY ...)`

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
