### PR TITLE
Fix bool_or behavior

### DIFF
--- a/dbt/include/clickhouse/macros/utils/utils.sql
+++ b/dbt/include/clickhouse/macros/utils/utils.sql
@@ -34,7 +34,7 @@
 
 
 {% macro clickhouse__bool_or(expression) -%}
-    any({{ expression }}) > 0
+    max({{ expression }}) > 0
 {%- endmacro %}
 
 


### PR DESCRIPTION
## Summary
No issue created, but I can open one if needed.

This fixes an issue with the cross-database dbt macro `bool_or`. It was using `any` which selects the first non-null column value.  This means it can return false even if there is a true in the same group.  Updated the function to use the max function instead.

__Example:__
```sql
with my_test_values as (
   select false as val
   union all 
   select true
   union all
   select null
)

select any(val), max(val)
from my_test_values

```

| any(val) | max(val) |
| -------- | --------- |
| false      | true         |


## Checklist
Delete items not relevant to your PR:
- [x] A human-readable description of the changes was provided to include in CHANGELOG