### PR TITLE
Fix: Dictionaries should be created on cluster when cluster is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+#### Bug Fix
+- ClickHouse dictionaries are now correctly created "on cluster" when a cluster is defined.
+
 ### Release [1.7.6], 2024-04-12
 #### Bug Fix
 - A bug in (experimental) Distributed Table model creation could lead to errors when there was a change in the model definition (see, e.g.,

--- a/dbt/adapters/clickhouse/relation.py
+++ b/dbt/adapters/clickhouse/relation.py
@@ -81,7 +81,10 @@ class ClickHouseRelation(BaseRelation):
         cls: Type[Self], cluster: str = '', materialized: str = '', engine: str = ''
     ) -> bool:
         if cluster.strip():
-            return 'view' == materialized or 'distributed' in materialized or 'Replicated' in engine
+            return materialized in ('view', 'dictionary') or \
+                'distributed' in materialized or \
+                'Replicated' in engine
+
         else:
             return False
 


### PR DESCRIPTION
## Summary
Fixes an issue where dictionaries are not correctly run "ON CLUSTER" when a cluster is defined.

## Checklist
- [x] A human-readable description of the changes was provided to include in CHANGELOG
