### PR TITLE
feat: support query_settings in view materialization

### DIFF
--- a/dbt/include/clickhouse/macros/materializations/view.sql
+++ b/dbt/include/clickhouse/macros/materializations/view.sql
@@ -78,6 +78,7 @@
     {%- endif %}
   as (
     {{ sql }}
+    {{ adapter.get_model_query_settings(model) }}
   )
       {% if model.get('config').get('materialized') == 'view' %}
       {{ adapter.get_model_settings(model) }}


### PR DESCRIPTION
## Summary

Currently the `settings` configuration option is used when creating a view, but only at view **creation** time. These settings do not persist when actually querying the view, so this PR adds the option to use the separate `query_settings` config option to create a view with settings that persist at query time.

My specific use case is to allow `join_use_nulls=1` to be set within dbt, rather than remembering to include this setting every time I query the view.   

I'm a first timer here, so have a few questions too,
- There's no open issue yet - should I create one?
- I didn't see any tests that were relevant to this change, but if there are some that cover this just lemme know and I'll add some in :)
- Would also be great to know what specific docs would need to change if this is merged in?