### PR TITLE
__dbt_backup relation dropped on cluster for dictionaries (fixes #325)

### DIFF
--- a/dbt/include/clickhouse/macros/materializations/dictionary.sql
+++ b/dbt/include/clickhouse/macros/materializations/dictionary.sql
@@ -42,7 +42,7 @@
 
   {{ adapter.commit() }}
 
-  {{ drop_dictionary_if_exists(backup_relation) }}
+  {{ drop_dictionary_if_exists(backup_relation, cluster_clause) }}
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 


### PR DESCRIPTION
## Summary
fixes #325

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
