### PR TITLE
Feat/apply incremental schema changes

### DIFF
--- a/dbt/adapters/clickhouse/column.py
+++ b/dbt/adapters/clickhouse/column.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import dataclass, field
-from typing import Any, TypeVar, Literal, List
+from typing import Any, List, Literal, TypeVar
 
 from dbt.adapters.base.column import Column
 from dbt_common.exceptions import DbtRuntimeError

--- a/dbt/adapters/clickhouse/column.py
+++ b/dbt/adapters/clickhouse/column.py
@@ -163,4 +163,3 @@ class ClickHouseColumnChanges:
             return True
 
         return False
-

--- a/dbt/adapters/clickhouse/errors.py
+++ b/dbt/adapters/clickhouse/errors.py
@@ -1,14 +1,14 @@
 schema_change_fail_error = """
 The source and target schemas on this incremental model are out of sync.
-        They can be reconciled in several ways:
-          - set the `on_schema_change` config to `append_new_columns`.  (ClickHouse does not support `sync_all_columns`)
-          - Re-run the incremental model with `full_refresh: True` to update the target schema.
-          - update the schema manually and re-run the process.
+They can be reconciled in several ways:
+  - set the `on_schema_change` config to `append_new_columns` or `sync_all_columns`.
+  - Re-run the incremental model with `full_refresh: True` to update the target schema.
+  - update the schema manually and re-run the process.
 
-        Additional troubleshooting context:
-           Source columns not in target: {0}
-           Target columns not in source: {1}
-           New column types: {2}
+Additional troubleshooting context:
+   Source columns not in target: {0}
+   Target columns not in source: {1}
+   New column types: {2}
 """
 
 schema_change_datatype_error = """

--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -29,7 +29,7 @@ from dbt_common.exceptions import DbtInternalError, DbtRuntimeError, NotImplemen
 from dbt_common.utils import filter_null_values
 
 from dbt.adapters.clickhouse.cache import ClickHouseRelationsCache
-from dbt.adapters.clickhouse.column import ClickHouseColumn
+from dbt.adapters.clickhouse.column import ClickHouseColumn, ClickHouseColumnChanges
 from dbt.adapters.clickhouse.connections import ClickHouseConnectionManager
 from dbt.adapters.clickhouse.errors import (
     schema_change_datatype_error,
@@ -39,7 +39,7 @@ from dbt.adapters.clickhouse.errors import (
 from dbt.adapters.clickhouse.logger import logger
 from dbt.adapters.clickhouse.query import quote_identifier
 from dbt.adapters.clickhouse.relation import ClickHouseRelation, ClickHouseRelationType
-from dbt.adapters.clickhouse.util import NewColumnDataType, compare_versions
+from dbt.adapters.clickhouse.util import compare_versions
 
 if TYPE_CHECKING:
     import agate
@@ -193,35 +193,33 @@ class ClickHouseAdapter(SQLAdapter):
     @available.parse_none
     def check_incremental_schema_changes(
         self, on_schema_change, existing, target_sql
-    ) -> List[ClickHouseColumn]:
-        if on_schema_change not in ('fail', 'ignore', 'append_new_columns'):
-            raise DbtRuntimeError(
-                "Only `fail`, `ignore`, and `append_new_columns` supported for `on_schema_change`"
-            )
+    ) -> ClickHouseColumnChanges:
         source = self.get_columns_in_relation(existing)
         source_map = {column.name: column for column in source}
         target = self.get_column_schema_from_query(target_sql)
-        target_map = {column.name: column for column in source}
+        target_map = {column.name: column for column in target}
+
         source_not_in_target = [column for column in source if column.name not in target_map.keys()]
         target_not_in_source = [column for column in target if column.name not in source_map.keys()]
-        new_column_data_types = []
-        for target_column in target:
-            source_column = source_map.get(target_column.name)
-            if source_column and source_column.dtype != target_column.dtype:
-                new_column_data_types.append(
-                    NewColumnDataType(source_column.name, target_column.dtype)
-                )
-        if new_column_data_types:
-            raise DbtRuntimeError(schema_change_datatype_error.format(new_column_data_types))
-        if source_not_in_target:
-            raise DbtRuntimeError(schema_change_missing_source_error.format(source_not_in_target))
-        if target_not_in_source and on_schema_change == 'fail':
+        target_in_source = [column for column in target if column.name in source_map.keys()]
+        changed_data_types = [column for column in target_in_source
+                              if column.dtype != source_map.get(column.name).dtype]
+
+        clickhouse_column_changes = ClickHouseColumnChanges(
+            columns_to_add=target_not_in_source,
+            columns_to_drop=source_not_in_target,
+            columns_to_modify=changed_data_types,
+            on_schema_change=on_schema_change,
+        )
+
+        if clickhouse_column_changes.has_conflicting_changes:
             raise DbtRuntimeError(
                 schema_change_fail_error.format(
-                    source_not_in_target, target_not_in_source, new_column_data_types
+                    source_not_in_target, target_not_in_source, changed_data_types
                 )
             )
-        return target_not_in_source
+
+        return clickhouse_column_changes
 
     @available.parse_none
     def s3source_clause(

--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -207,11 +207,11 @@ class ClickHouseAdapter(SQLAdapter):
         source_not_in_target = [column for column in source if column.name not in target_map.keys()]
         target_not_in_source = [column for column in target if column.name not in source_map.keys()]
         target_in_source = [column for column in target if column.name in source_map.keys()]
-        changed_data_types = [
-            column
-            for column in target_in_source
-            if column.dtype != source_map.get(column.name).dtype
-        ]
+        changed_data_types = []
+        for column in target_in_source:
+            source_column = source_map.get(column.name)
+            if source_column is not None and column.dtype != source_column.dtype:
+                changed_data_types.append(column)
 
         clickhouse_column_changes = ClickHouseColumnChanges(
             columns_to_add=target_not_in_source,

--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -194,6 +194,11 @@ class ClickHouseAdapter(SQLAdapter):
     def check_incremental_schema_changes(
         self, on_schema_change, existing, target_sql
     ) -> ClickHouseColumnChanges:
+        if on_schema_change not in ('fail', 'ignore', 'append_new_columns', 'sync_all_columns'):
+            raise DbtRuntimeError(
+                "Only `fail`, `ignore`, `append_new_columns`, and `sync_all_columns` supported for `on_schema_change`."
+            )
+
         source = self.get_columns_in_relation(existing)
         source_map = {column.name: column for column in source}
         target = self.get_column_schema_from_query(target_sql)

--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -207,8 +207,11 @@ class ClickHouseAdapter(SQLAdapter):
         source_not_in_target = [column for column in source if column.name not in target_map.keys()]
         target_not_in_source = [column for column in target if column.name not in source_map.keys()]
         target_in_source = [column for column in target if column.name in source_map.keys()]
-        changed_data_types = [column for column in target_in_source
-                              if column.dtype != source_map.get(column.name).dtype]
+        changed_data_types = [
+            column
+            for column in target_in_source
+            if column.dtype != source_map.get(column.name).dtype
+        ]
 
         clickhouse_column_changes = ClickHouseColumnChanges(
             columns_to_add=target_not_in_source,

--- a/dbt/adapters/clickhouse/util.py
+++ b/dbt/adapters/clickhouse/util.py
@@ -13,9 +13,3 @@ def compare_versions(v1: str, v2: str) -> int:
         except ValueError:
             raise DbtRuntimeError("Version must consist of only numbers separated by '.'")
     return 0
-
-
-@dataclass
-class NewColumnDataType:
-    column_name: str
-    new_type: str

--- a/dbt/include/clickhouse/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/clickhouse/macros/materializations/incremental/incremental.sql
@@ -191,7 +191,6 @@
        + '__dbt_new_data_' + invocation_id.replace('-', '_')}) %}
     {{ drop_relation_if_exists(new_data_relation) }}
     {%- set distributed_new_data_relation = existing_relation.incorporate(path={"identifier": existing_relation.identifier + '__dbt_distributed_new_data'}) -%}
-    {{ drop_relation_if_exists(distributed_new_data_relation) }}
 
     {%- set inserting_relation = new_data_relation -%}
 
@@ -231,4 +230,5 @@
         insert into {{ existing_relation }} select {{ dest_cols_csv }} from {{ inserting_relation }} {{ adapter.get_model_query_settings(model) }}
     {% endcall %}
     {% do adapter.drop_relation(new_data_relation) %}
+    {{ drop_relation_if_exists(distributed_new_data_relation) }}
 {% endmacro %}

--- a/dbt/include/clickhouse/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/clickhouse/macros/materializations/incremental/incremental.sql
@@ -191,6 +191,7 @@
        + '__dbt_new_data_' + invocation_id.replace('-', '_')}) %}
     {{ drop_relation_if_exists(new_data_relation) }}
     {%- set distributed_new_data_relation = existing_relation.incorporate(path={"identifier": existing_relation.identifier + '__dbt_distributed_new_data'}) -%}
+    {{ drop_relation_if_exists(distributed_new_data_relation) }}
 
     {%- set inserting_relation = new_data_relation -%}
 
@@ -230,5 +231,4 @@
         insert into {{ existing_relation }} select {{ dest_cols_csv }} from {{ inserting_relation }} {{ adapter.get_model_query_settings(model) }}
     {% endcall %}
     {% do adapter.drop_relation(new_data_relation) %}
-    {{ drop_relation_if_exists(distributed_new_data_relation) }}
 {% endmacro %}

--- a/dbt/include/clickhouse/macros/materializations/incremental/schema_changes.sql
+++ b/dbt/include/clickhouse/macros/materializations/incremental/schema_changes.sql
@@ -1,0 +1,66 @@
+{% macro clickhouse__apply_column_changes(column_changes, existing_relation, is_distributed=False) %}
+    {{ log('Schema changes detected. Trying to apply the following changes: ' ~ column_changes) }}
+    {%- set existing_local = none -%}
+    {% if is_distributed %}
+        {%- set local_suffix = adapter.get_clickhouse_local_suffix() -%}
+        {%- set local_db_prefix = adapter.get_clickhouse_local_db_prefix() -%}
+        {%- set existing_local = existing_relation.incorporate(path={"identifier": this.identifier + local_suffix, "schema": local_db_prefix + this.schema}) if existing_relation is not none else none -%}
+    {% endif %}
+
+    {% if column_changes.on_schema_change == 'append_new_columns' %}
+        {% do clickhouse__add_columns(column_changes.columns_to_add, existing_relation, existing_local, is_distributed) %}
+
+    {% elif column_changes.on_schema_change == 'sync_all_columns' %}
+        {% do clickhouse__drop_columns(column_changes.columns_to_drop, existing_relation, existing_local, is_distributed) %}
+        {% do clickhouse__add_columns(column_changes.columns_to_add, existing_relation, existing_local, is_distributed) %}
+        {% do clickhouse__modify_columns(column_changes.columns_to_modify, existing_relation, existing_local, is_distributed) %}
+    {% endif %}
+
+{% endmacro %}
+
+{% macro clickhouse__add_columns(columns, existing_relation, existing_local=none, is_distributed=False) %}
+    {% for column in columns %}
+        {% set alter_action -%}
+            add column if not exists `{{ column.name }}` {{ column.data_type }}
+        {%- endset %}
+        {% do clickhouse__run_alter_table_command(alter_action, existing_relation, existing_local, is_distributed) %}
+    {% endfor %}
+
+{% endmacro %}
+
+{% macro clickhouse__drop_columns(columns, existing_relation, existing_local=none, is_distributed=False) %}
+    {% for column in columns %}
+        {% set alter_action -%}
+            drop column if exists `{{ column.name }}`
+        {%- endset %}
+        {% do clickhouse__run_alter_table_command(alter_action, existing_relation, existing_local, is_distributed) %}
+    {% endfor %}
+
+{% endmacro %}
+
+{% macro clickhouse__modify_columns(columns, existing_relation, existing_local=none, is_distributed=False) %}
+    {% for column in columns %}
+        {% set alter_action -%}
+            modify column if exists `{{ column.name }}` {{ column.data_type }}
+        {%- endset %}
+        {% do clickhouse__run_alter_table_command(alter_action, existing_relation, existing_local, is_distributed) %}
+    {% endfor %}
+
+{% endmacro %}
+
+{% macro clickhouse__run_alter_table_command(alter_action, existing_relation, existing_local=none, is_distributed=False) %}
+    {% if is_distributed %}
+        {% call statement('alter_table') %}
+            alter table {{ existing_local }} {{ on_cluster_clause(existing_relation) }} {{ alter_action }}
+        {% endcall %}
+        {% call statement('alter_table') %}
+            alter table {{ existing_relation }} {{ on_cluster_clause(existing_relation) }} {{ alter_action }}
+        {% endcall %}
+
+    {% else %}
+        {% call statement('alter_table') %}
+            alter table {{ existing_relation }} {{ alter_action }}
+        {% endcall %}
+    {% endif %}
+
+{% endmacro %}

--- a/tests/integration/adapter/incremental/test_schema_change.py
+++ b/tests/integration/adapter/incremental/test_schema_change.py
@@ -1,5 +1,6 @@
 import pytest
 from dbt.tests.util import run_dbt, run_dbt_and_capture
+from functools import reduce
 
 schema_change_sql = """
 {{
@@ -138,10 +139,11 @@ class TestComplexSchemaChange:
         assert result[0][1] == 1
         run_dbt(["run", "--select", model])
         result = project.run_sql(f"select * from {model} order by col_1", fetch="all")
-        result_types = project.run_sql(f"select toColumnTypeName(col_1) from {model}", fetch="one")
-        assert result_types[0] == 'Float32'
+        assert all(len(row) == 2 for row in result)
         assert result[0][1] == 0
         assert result[3][1] == 5
+        result_types = project.run_sql(f"select toColumnTypeName(col_1) from {model}", fetch="one")
+        assert result_types[0] == 'Float32'
 
 
 out_of_order_columns_sql = """

--- a/tests/integration/adapter/incremental/test_schema_change.py
+++ b/tests/integration/adapter/incremental/test_schema_change.py
@@ -33,9 +33,12 @@ class TestOnSchemaChange:
             "schema_change_ignore.sql": schema_change_sql % ("incremental", "ignore"),
             "schema_change_fail.sql": schema_change_sql % ("incremental", "fail"),
             "schema_change_append.sql": schema_change_sql % ("incremental", "append_new_columns"),
-            "schema_change_distributed_ignore.sql": schema_change_sql % ("distributed_incremental", "ignore"),
-            "schema_change_distributed_fail.sql": schema_change_sql % ("distributed_incremental", "fail"),
-            "schema_change_distributed_append.sql": schema_change_sql % ("distributed_incremental", "append_new_columns"),
+            "schema_change_distributed_ignore.sql": schema_change_sql
+            % ("distributed_incremental", "ignore"),
+            "schema_change_distributed_fail.sql": schema_change_sql
+            % ("distributed_incremental", "fail"),
+            "schema_change_distributed_append.sql": schema_change_sql
+            % ("distributed_incremental", "append_new_columns"),
         }
 
     @pytest.mark.parametrize("model", ("schema_change_ignore", "schema_change_distributed_ignore"))
@@ -105,17 +108,27 @@ class TestComplexSchemaChange:
     def models(self):
         return {
             "complex_schema_change_fail.sql": complex_schema_change_sql % ("incremental", "fail"),
-            "complex_schema_change_append.sql": complex_schema_change_sql % ("incremental", "append_new_columns"),
-            "complex_schema_change_sync.sql": complex_schema_change_sql % ("incremental", "sync_all_columns"),
-            "complex_schema_change_distributed_fail.sql": complex_schema_change_sql % ("distributed_incremental", "fail"),
-            "complex_schema_change_distributed_append.sql": complex_schema_change_sql % ("distributed_incremental", "append_new_columns"),
-            "complex_schema_change_distributed_sync.sql": complex_schema_change_sql % ("distributed_incremental", "sync_all_columns"),
+            "complex_schema_change_append.sql": complex_schema_change_sql
+            % ("incremental", "append_new_columns"),
+            "complex_schema_change_sync.sql": complex_schema_change_sql
+            % ("incremental", "sync_all_columns"),
+            "complex_schema_change_distributed_fail.sql": complex_schema_change_sql
+            % ("distributed_incremental", "fail"),
+            "complex_schema_change_distributed_append.sql": complex_schema_change_sql
+            % ("distributed_incremental", "append_new_columns"),
+            "complex_schema_change_distributed_sync.sql": complex_schema_change_sql
+            % ("distributed_incremental", "sync_all_columns"),
         }
 
-    @pytest.mark.parametrize("model", ("complex_schema_change_fail",
-                                       "complex_schema_change_distributed_fail",
-                                       "complex_schema_change_append",
-                                       "complex_schema_change_distributed_append"))
+    @pytest.mark.parametrize(
+        "model",
+        (
+            "complex_schema_change_fail",
+            "complex_schema_change_distributed_fail",
+            "complex_schema_change_append",
+            "complex_schema_change_distributed_append",
+        ),
+    )
     def test_fail(self, project, model):
         run_dbt(["run", "--select", model])
         result = project.run_sql(f"select * from {model} order by col_1", fetch="all")
@@ -131,7 +144,9 @@ class TestComplexSchemaChange:
         )
         assert 'out of sync' in log_output.lower()
 
-    @pytest.mark.parametrize("model", ("complex_schema_change_sync", "complex_schema_change_distributed_sync"))
+    @pytest.mark.parametrize(
+        "model", ("complex_schema_change_sync", "complex_schema_change_distributed_sync")
+    )
     def test_sync(self, project, model):
         run_dbt(["run", "--select", model])
         result = project.run_sql(f"select * from {model} order by col_1", fetch="all")
@@ -174,7 +189,8 @@ class TestReordering:
     def models(self):
         return {
             "out_of_order_columns.sql": out_of_order_columns_sql % "incremental",
-            "out_of_order_columns_distributed.sql": out_of_order_columns_sql % "distributed_incremental",
+            "out_of_order_columns_distributed.sql": out_of_order_columns_sql
+            % "distributed_incremental",
         }
 
     @pytest.mark.parametrize("model", ("out_of_order_columns", "out_of_order_columns_distributed"))

--- a/tests/integration/adapter/incremental/test_schema_change.py
+++ b/tests/integration/adapter/incremental/test_schema_change.py
@@ -1,6 +1,7 @@
+from functools import reduce
+
 import pytest
 from dbt.tests.util import run_dbt, run_dbt_and_capture
-from functools import reduce
 
 schema_change_sql = """
 {{

--- a/tests/integration/adapter/incremental/test_schema_change.py
+++ b/tests/integration/adapter/incremental/test_schema_change.py
@@ -69,3 +69,80 @@ class TestOnSchemaChange:
         result = project.run_sql("select * from schema_change_append order by col_1", fetch="all")
         assert result[0][2] == 0
         assert result[3][2] == 5
+
+
+# contains dropped, added, and (type) changed columns
+complex_schema_change_sql = """
+{{
+    config(
+        materialized='incremental',
+        unique_key='col_1',
+        on_schema_change='%schema_change%'
+    )
+}}
+
+{% if not is_incremental() %}
+select
+    toUInt8(number) as col_1,
+    number + 1 as col_2
+from numbers(3)
+{% else %}
+select
+    toFloat32(number) as col_1,
+    number + 2 as col_3
+from numbers(2, 3)
+{% endif %}
+"""
+
+
+class TestComplexSchemaChange:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "complex_schema_change_fail.sql": complex_schema_change_sql.replace("%schema_change%", "fail"),
+            "complex_schema_change_append.sql": complex_schema_change_sql.replace("%schema_change%",
+                                                                                  "append_new_columns"),
+            "complex_schema_change_sync.sql": complex_schema_change_sql.replace("%schema_change%", "sync_all_columns"),
+        }
+
+    def test_fail(self, project):
+        run_dbt(["run", "--select", "complex_schema_change_fail"])
+        result = project.run_sql("select * from complex_schema_change_fail order by col_1", fetch="all")
+        assert len(result) == 3
+        assert result[0][1] == 1
+        _, log_output = run_dbt_and_capture(
+            [
+                "run",
+                "--select",
+                "complex_schema_change_fail",
+            ],
+            expect_pass=False,
+        )
+        assert 'out of sync' in log_output.lower()
+
+    def test_append(self, project):
+        run_dbt(["run", "--select", "complex_schema_change_append"])
+        result = project.run_sql("select * from complex_schema_change_append order by col_1", fetch="all")
+        assert len(result) == 3
+        assert result[0][1] == 1
+        _, log_output = run_dbt_and_capture(
+            [
+                "run",
+                "--select",
+                "complex_schema_change_append",
+            ],
+            expect_pass=False,
+        )
+        assert 'out of sync' in log_output.lower()
+
+    def test_sync(self, project):
+        run_dbt(["run", "--select", "complex_schema_change_sync"])
+        result = project.run_sql("select * from complex_schema_change_sync order by col_1", fetch="all")
+        assert len(result) == 3
+        assert result[0][1] == 1
+        run_dbt(["run", "--select", "complex_schema_change_sync"])
+        result = project.run_sql("select * from complex_schema_change_sync order by col_1", fetch="all")
+        result_types = project.run_sql("select toColumnTypeName(col_1) from complex_schema_change_sync", fetch="one")
+        assert result_types[0] == 'Float32'
+        assert result[0][1] == 0
+        assert result[3][1] == 5

--- a/tests/integration/adapter/incremental/test_schema_change.py
+++ b/tests/integration/adapter/incremental/test_schema_change.py
@@ -4,24 +4,24 @@ from dbt.tests.util import run_dbt, run_dbt_and_capture
 schema_change_sql = """
 {{
     config(
-        materialized='incremental',
+        materialized='%s',
         unique_key='col_1',
-        on_schema_change='%schema_change%'
+        on_schema_change='%s'
     )
 }}
 
-{% if not is_incremental() %}
+{%% if not is_incremental() %%}
 select
     number as col_1,
     number + 1 as col_2
 from numbers(3)
-{% else %}
+{%% else %%}
 select
     number as col_1,
     number + 1 as col_2,
     number + 2 as col_3
 from numbers(2, 3)
-{% endif %}
+{%% endif %%}
 """
 
 
@@ -29,69 +29,73 @@ class TestOnSchemaChange:
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "schema_change_ignore.sql": schema_change_sql.replace("%schema_change%", "ignore"),
-            "schema_change_fail.sql": schema_change_sql.replace("%schema_change%", "fail"),
-            "schema_change_append.sql": schema_change_sql.replace(
-                "%schema_change%", "append_new_columns"
-            ),
+            "schema_change_ignore.sql": schema_change_sql % ("incremental", "ignore"),
+            "schema_change_fail.sql": schema_change_sql % ("incremental", "fail"),
+            "schema_change_append.sql": schema_change_sql % ("incremental", "append_new_columns"),
+            "schema_change_distributed_ignore.sql": schema_change_sql % ("distributed_incremental", "ignore"),
+            "schema_change_distributed_fail.sql": schema_change_sql % ("distributed_incremental", "fail"),
+            "schema_change_distributed_append.sql": schema_change_sql % ("distributed_incremental", "append_new_columns"),
         }
 
-    def test_ignore(self, project):
-        run_dbt(["run", "--select", "schema_change_ignore"])
-        result = project.run_sql("select * from schema_change_ignore order by col_1", fetch="all")
+    @pytest.mark.parametrize("model", ("schema_change_ignore", "schema_change_distributed_ignore"))
+    def test_ignore(self, project, model):
+        run_dbt(["run", "--select", model])
+        result = project.run_sql(f"select * from {model} order by col_1", fetch="all")
         assert len(result) == 3
         assert result[0][1] == 1
-        run_dbt(["run", "--select", "schema_change_ignore"])
-        result = project.run_sql("select * from schema_change_ignore", fetch="all")
+        run_dbt(["run", "--select", model])
+        result = project.run_sql(f"select * from {model}", fetch="all")
         assert len(result) == 5
 
-    def test_fail(self, project):
-        run_dbt(["run", "--select", "schema_change_fail"])
-        result = project.run_sql("select * from schema_change_fail order by col_1", fetch="all")
+    @pytest.mark.parametrize("model", ("schema_change_fail", "schema_change_distributed_fail"))
+    def test_fail(self, project, model):
+        run_dbt(["run", "--select", model])
+        result = project.run_sql(f"select * from {model} order by col_1", fetch="all")
         assert len(result) == 3
         assert result[0][1] == 1
         _, log_output = run_dbt_and_capture(
             [
                 "run",
                 "--select",
-                "schema_change_fail",
+                model,
             ],
             expect_pass=False,
         )
         assert 'out of sync' in log_output.lower()
 
-    def test_append(self, project):
-        run_dbt(["run", "--select", "schema_change_append"])
-        result = project.run_sql("select * from schema_change_append order by col_1", fetch="all")
+    @pytest.mark.parametrize("model", ("schema_change_append", "schema_change_distributed_append"))
+    def test_append(self, project, model):
+        run_dbt(["run", "--select", model])
+        result = project.run_sql(f"select * from {model} order by col_1", fetch="all")
         assert len(result) == 3
         assert result[0][1] == 1
-        run_dbt(["--debug", "run", "--select", "schema_change_append"])
-        result = project.run_sql("select * from schema_change_append order by col_1", fetch="all")
+        run_dbt(["--debug", "run", "--select", model])
+        result = project.run_sql(f"select * from {model} order by col_1", fetch="all")
         assert result[0][2] == 0
         assert result[3][2] == 5
 
 
-# contains dropped, added, and (type) changed columns
+# contains dropped, added, and changed (type) columns
 complex_schema_change_sql = """
 {{
     config(
-        materialized='incremental',
+        materialized='%s',
         unique_key='col_1',
-        on_schema_change='%schema_change%'
+        on_schema_change='%s'
     )
 }}
 
-{% if not is_incremental() %}
+{%% if not is_incremental() %%}
 select
     toUInt8(number) as col_1,
     number + 1 as col_2
 from numbers(3)
-{% else %}
+{%% else %%}
 select
     toFloat32(number) as col_1,
     number + 2 as col_3
 from numbers(2, 3)
-{% endif %}
+{%% endif %%}
 """
 
 
@@ -99,50 +103,42 @@ class TestComplexSchemaChange:
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "complex_schema_change_fail.sql": complex_schema_change_sql.replace("%schema_change%", "fail"),
-            "complex_schema_change_append.sql": complex_schema_change_sql.replace("%schema_change%",
-                                                                                  "append_new_columns"),
-            "complex_schema_change_sync.sql": complex_schema_change_sql.replace("%schema_change%", "sync_all_columns"),
+            "complex_schema_change_fail.sql": complex_schema_change_sql % ("incremental", "fail"),
+            "complex_schema_change_append.sql": complex_schema_change_sql % ("incremental", "append_new_columns"),
+            "complex_schema_change_sync.sql": complex_schema_change_sql % ("incremental", "sync_all_columns"),
+            "complex_schema_change_distributed_fail.sql": complex_schema_change_sql % ("distributed_incremental", "fail"),
+            "complex_schema_change_distributed_append.sql": complex_schema_change_sql % ("distributed_incremental", "append_new_columns"),
+            "complex_schema_change_distributed_sync.sql": complex_schema_change_sql % ("distributed_incremental", "sync_all_columns"),
         }
 
-    def test_fail(self, project):
-        run_dbt(["run", "--select", "complex_schema_change_fail"])
-        result = project.run_sql("select * from complex_schema_change_fail order by col_1", fetch="all")
+    @pytest.mark.parametrize("model", ("complex_schema_change_fail",
+                                       "complex_schema_change_distributed_fail",
+                                       "complex_schema_change_append",
+                                       "complex_schema_change_distributed_append"))
+    def test_fail(self, project, model):
+        run_dbt(["run", "--select", model])
+        result = project.run_sql(f"select * from {model} order by col_1", fetch="all")
         assert len(result) == 3
         assert result[0][1] == 1
         _, log_output = run_dbt_and_capture(
             [
                 "run",
                 "--select",
-                "complex_schema_change_fail",
+                model,
             ],
             expect_pass=False,
         )
         assert 'out of sync' in log_output.lower()
 
-    def test_append(self, project):
-        run_dbt(["run", "--select", "complex_schema_change_append"])
-        result = project.run_sql("select * from complex_schema_change_append order by col_1", fetch="all")
+    @pytest.mark.parametrize("model", ("complex_schema_change_sync", "complex_schema_change_distributed_sync"))
+    def test_sync(self, project, model):
+        run_dbt(["run", "--select", model])
+        result = project.run_sql(f"select * from {model} order by col_1", fetch="all")
         assert len(result) == 3
         assert result[0][1] == 1
-        _, log_output = run_dbt_and_capture(
-            [
-                "run",
-                "--select",
-                "complex_schema_change_append",
-            ],
-            expect_pass=False,
-        )
-        assert 'out of sync' in log_output.lower()
-
-    def test_sync(self, project):
-        run_dbt(["run", "--select", "complex_schema_change_sync"])
-        result = project.run_sql("select * from complex_schema_change_sync order by col_1", fetch="all")
-        assert len(result) == 3
-        assert result[0][1] == 1
-        run_dbt(["run", "--select", "complex_schema_change_sync"])
-        result = project.run_sql("select * from complex_schema_change_sync order by col_1", fetch="all")
-        result_types = project.run_sql("select toColumnTypeName(col_1) from complex_schema_change_sync", fetch="one")
+        run_dbt(["run", "--select", model])
+        result = project.run_sql(f"select * from {model} order by col_1", fetch="all")
+        result_types = project.run_sql(f"select toColumnTypeName(col_1) from {model}", fetch="one")
         assert result_types[0] == 'Float32'
         assert result[0][1] == 0
         assert result[3][1] == 5


### PR DESCRIPTION
## Summary
implementation of schema changes for incremental models are currently missing. detecting schema changes during materialization would fallback to the legacy incremental strategy. this is not user-friendly and not feasible for very large models. schema changes for distributed_incremental materialization were not supported at all.

this pr contains
- support for applying schema changes for `incremental` and `distributed_incremental` materializations
- implementation of the `on_schema_change='sync_all_column'` strategy as per official [dbt specs](https://docs.getdbt.com/docs/build/incremental-models#what-if-the-columns-of-my-incremental-model-change)
- fix of an issue in distributed_incremental materialzation and `on_schema_change='ignore'`, where new columns in the target relation would break the dbt run during creation of the `__dbt_new_data_` tables
- fix of an issue in distributed_incremental materialzation, where column order changes would break the dbt run (or insert data to the wrong columns)

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
