### PR TITLE
feat: allow adding an empty seed without rows

### DIFF
--- a/dbt/include/clickhouse/macros/materializations/seed.sql
+++ b/dbt/include/clickhouse/macros/materializations/seed.sql
@@ -2,14 +2,16 @@
   {% set cols_sql = get_seed_column_quoted_csv(model, agate_table.column_names) %}
   {% set data_sql = adapter.get_csv_data(agate_table) %}
 
-  {% set sql -%}
-    insert into {{ this.render() }} ({{ cols_sql }})
-    {{ adapter.get_model_query_settings(model) }}
-    format CSV
-    {{ data_sql }}
-  {%- endset %}
+  {% if data_sql %}
+    {% set sql -%}
+      insert into {{ this.render() }} ({{ cols_sql }})
+      {{ adapter.get_model_query_settings(model) }}
+      format CSV
+      {{ data_sql }}
+    {%- endset %}
 
-  {% do adapter.add_query(sql, bindings=agate_table, abridge_sql_log=True) %}
+    {% do adapter.add_query(sql, bindings=agate_table, abridge_sql_log=True) %}
+  {% endif %}
 {% endmacro %}
 
 {% macro clickhouse__create_csv_table(model, agate_table) %}


### PR DESCRIPTION
## Summary
Fixes #330: allow inserting an empty seed with column names only (in fact create table and do not insert anything)

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
