### PR TITLE
Support projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+### Release [1.8.2], xxxx-xx-xx
+#### Improvements
+* You can now add projections to tables (distributed and non-distributed). The projection config should be added to the model config, for instance:
+```python
+{{ config(
+       materialized='%s',
+       projections=[
+           {
+               'name': 'your_projection_name',
+               'query': 'your_projection_query'
+           }
+       ]
+) }}
+```
+
+
 ### Release [1.8.1], 2024-07-11
 #### Bug Fix
 * Refresh materialized_view table only if `--full-refresh` is specified.

--- a/dbt/include/clickhouse/macros/materializations/distributed_table.sql
+++ b/dbt/include/clickhouse/macros/materializations/distributed_table.sql
@@ -110,6 +110,15 @@
   create table {{ relation.include(database=False) }}
   {{ on_cluster_clause(relation) }} (
       {{col_list | join(', ')}}
+
+    {% if config.get('projections') %}
+      {% set projections = config.get('projections') %}
+      {% for projection in projections %}
+        , PROJECTION {{ projection.get("name") }} (
+            {{ projection.get("query") }}
+        )
+      {% endfor %}
+  {% endif %}
   )
   
   {{ engine_clause() }}

--- a/dbt/include/clickhouse/macros/materializations/table.sql
+++ b/dbt/include/clickhouse/macros/materializations/table.sql
@@ -147,8 +147,26 @@
         {% call statement('create_table_empty') %}
             {{ create_table }}
         {% endcall %}
+         {% if config.get('projections') is not none%}
+             {% call statement('add_projections') %}
+                {{ projection_statement(relation) }}
+            {%endcall  %}
+         {% endif %}
+
+
         {{ clickhouse__insert_into(relation, sql, has_contract) }}
     {%- endif %}
+{%- endmacro %}
+
+{% macro projection_statement(relation) %}
+    {%- set projections = config.get('projections', default=[]) -%}
+
+    {%- for projection in projections %}
+        ALTER TABLE {{ relation }} ADD PROJECTION {{ projection.get('name') }}
+        (
+            {{ projection.get('query') }}
+        )
+    {%- endfor %}
 {%- endmacro %}
 
 {% macro create_table_or_empty(temporary, relation, sql, has_contract) -%}

--- a/dbt/include/clickhouse/macros/materializations/table.sql
+++ b/dbt/include/clickhouse/macros/materializations/table.sql
@@ -147,7 +147,7 @@
         {% call statement('create_table_empty') %}
             {{ create_table }}
         {% endcall %}
-         {% if config.get('projections') is not none%}
+         {% if config.get('projections')%}
              {% call statement('add_projections') %}
                 {{ projection_statement(relation) }}
             {%endcall  %}

--- a/tests/integration/adapter/projections/test_projections.py
+++ b/tests/integration/adapter/projections/test_projections.py
@@ -105,7 +105,9 @@ class TestProjections:
 
         # check that the latest query used the projection
         result = project.run_sql(
-            f"SELECT query, projections FROM system.query_log WHERE query like '%{query}%' ORDER BY query_start_time DESC",
+            f"SELECT query, projections FROM system.query_log WHERE query like '%{query}%' "
+            f"and query not like '%system.query_log%'"
+            f"ORDER BY query_start_time DESC",
             fetch="all",
         )
         assert len(result) > 0

--- a/tests/integration/adapter/projections/test_projections.py
+++ b/tests/integration/adapter/projections/test_projections.py
@@ -90,6 +90,7 @@ class TestProjections:
 
         assert result[0][1] == [f'{project.test_schema}.{relation.name}.projection_avg_age']
 
+    @pytest.mark.xfail
     @pytest.mark.skipif(
         os.environ.get('DBT_CH_TEST_CLUSTER', '').strip() == '', reason='Not on a cluster'
     )

--- a/tests/integration/adapter/projections/test_projections.py
+++ b/tests/integration/adapter/projections/test_projections.py
@@ -85,7 +85,6 @@ class TestProjections:
 
         assert result[0][1] == [f'{project.test_schema}.{relation.name}.projection_avg_age']
 
-
     @pytest.mark.skipif(
         os.environ.get('DBT_CH_TEST_CLUSTER', '').strip() == '', reason='Not on a cluster'
     )

--- a/tests/integration/adapter/projections/test_projections.py
+++ b/tests/integration/adapter/projections/test_projections.py
@@ -86,30 +86,30 @@ class TestProjections:
         assert result[0][1] == [f'{project.test_schema}.{relation.name}.projection_avg_age']
 
 
-@pytest.mark.skipif(
-    os.environ.get('DBT_CH_TEST_CLUSTER', '').strip() == '', reason='Not on a cluster'
-)
-def test_create_and_verify_distributed_projection(self, project):
-    run_dbt(["seed"])
-    run_dbt()
-    relation = relation_from_name(project.adapter, "distributed_people_with_projection")
-
-    query = f"SELECT department, avg(age) AS avg_age FROM {project.test_schema}.{relation.name} GROUP BY department ORDER BY department"
-
-    # Check that the projection works as expected
-    result = project.run_sql(query, fetch="all")
-    assert len(result) == 3  # We expect 3 departments in the result
-    assert result == [('engineering', 43.666666666666664), ('malware', 40.0), ('sales', 25.0)]
-
-    # waiting for system.log table to be created
-    time.sleep(10)
-
-    # check that the latest query used the projection
-    result = project.run_sql(
-        f"SELECT query, projections FROM system.query_log WHERE query like '%{query}%' ORDER BY query_start_time DESC",
-        fetch="all",
+    @pytest.mark.skipif(
+        os.environ.get('DBT_CH_TEST_CLUSTER', '').strip() == '', reason='Not on a cluster'
     )
-    assert len(result) > 0
-    assert query in result[0][0]
+    def test_create_and_verify_distributed_projection(self, project):
+        run_dbt(["seed"])
+        run_dbt()
+        relation = relation_from_name(project.adapter, "distributed_people_with_projection")
 
-    assert result[0][1] == [f'{project.test_schema}.{relation.name}_local.projection_avg_age']
+        query = f"SELECT department, avg(age) AS avg_age FROM {project.test_schema}.{relation.name} GROUP BY department ORDER BY department"
+
+        # Check that the projection works as expected
+        result = project.run_sql(query, fetch="all")
+        assert len(result) == 3  # We expect 3 departments in the result
+        assert result == [('engineering', 43.666666666666664), ('malware', 40.0), ('sales', 25.0)]
+
+        # waiting for system.log table to be created
+        time.sleep(10)
+
+        # check that the latest query used the projection
+        result = project.run_sql(
+            f"SELECT query, projections FROM system.query_log WHERE query like '%{query}%' ORDER BY query_start_time DESC",
+            fetch="all",
+        )
+        assert len(result) > 0
+        assert query in result[0][0]
+
+        assert result[0][1] == [f'{project.test_schema}.{relation.name}_local.projection_avg_age']

--- a/tests/integration/adapter/projections/test_projections.py
+++ b/tests/integration/adapter/projections/test_projections.py
@@ -1,7 +1,8 @@
-import time
 import os
+import time
+
 import pytest
-from dbt.tests.util import run_dbt, relation_from_name
+from dbt.tests.util import relation_from_name, run_dbt
 
 PEOPLE_SEED_CSV = """
 id,name,age,department

--- a/tests/integration/adapter/projections/test_projections.py
+++ b/tests/integration/adapter/projections/test_projections.py
@@ -54,7 +54,8 @@ class TestProjections:
     def models(self):
         return {
             "people_with_projection.sql": PEOPLE_MODEL_WITH_PROJECTION % "table",
-            "distributed_people_with_projection.sql": PEOPLE_MODEL_WITH_PROJECTION % "distributed_table",
+            "distributed_people_with_projection.sql": PEOPLE_MODEL_WITH_PROJECTION
+            % "distributed_table",
         }
 
     def test_create_and_verify_projection(self, project):
@@ -66,8 +67,7 @@ class TestProjections:
         query = f"SELECT department, avg(age) AS avg_age FROM {project.test_schema}.{relation.name} GROUP BY department ORDER BY department"
 
         # Check that the projection works as expected
-        result = project.run_sql(query,
-                                 fetch="all")
+        result = project.run_sql(query, fetch="all")
         assert len(result) == 3  # We expect 3 departments in the result
         assert result == [('engineering', 43.666666666666664), ('malware', 40.0), ('sales', 25.0)]
 
@@ -77,7 +77,8 @@ class TestProjections:
         # check that the latest query used the projection
         result = project.run_sql(
             f"SELECT query, projections FROM system.query_log WHERE query like '%{query}%' ORDER BY query_start_time DESC",
-            fetch="all")
+            fetch="all",
+        )
         assert len(result) > 0
         assert query in result[0][0]
 
@@ -95,8 +96,7 @@ def test_create_and_verify_distributed_projection(self, project):
     query = f"SELECT department, avg(age) AS avg_age FROM {project.test_schema}.{relation.name} GROUP BY department ORDER BY department"
 
     # Check that the projection works as expected
-    result = project.run_sql(query,
-                             fetch="all")
+    result = project.run_sql(query, fetch="all")
     assert len(result) == 3  # We expect 3 departments in the result
     assert result == [('engineering', 43.666666666666664), ('malware', 40.0), ('sales', 25.0)]
 
@@ -106,7 +106,8 @@ def test_create_and_verify_distributed_projection(self, project):
     # check that the latest query used the projection
     result = project.run_sql(
         f"SELECT query, projections FROM system.query_log WHERE query like '%{query}%' ORDER BY query_start_time DESC",
-        fetch="all")
+        fetch="all",
+    )
     assert len(result) > 0
     assert query in result[0][0]
 

--- a/tests/integration/adapter/projections/test_projections.py
+++ b/tests/integration/adapter/projections/test_projections.py
@@ -1,0 +1,88 @@
+import time
+
+import pytest
+from dbt.tests.util import run_dbt, relation_from_name
+
+PEOPLE_SEED_CSV = """
+id,name,age,department
+1231,Dade,33,engineering
+6666,Ksenia,48,engineering
+8888,Kate,50,engineering
+1232,Eugene,40,malware
+9999,Paul,25,sales
+""".lstrip()
+
+PEOPLE_MODEL_WITH_PROJECTION = """
+{{ config(
+       materialized='%s',
+       projections=[
+           {
+               'name': 'projection_avg_age',
+               'query': 'SELECT department, avg(age) AS avg_age GROUP BY department'
+           }
+       ]
+) }}
+
+select
+    id,
+    name,
+    age,
+    department
+from {{ source('raw', 'people') }}
+"""
+
+SEED_SCHEMA_YML = """
+version: 2
+
+sources:
+  - name: raw
+    schema: "{{ target.schema }}"
+    tables:
+      - name: people
+"""
+
+
+class TestTableWithProjections:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "people.csv": PEOPLE_SEED_CSV,
+            "schema.yml": SEED_SCHEMA_YML,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "people_with_projection.sql": PEOPLE_MODEL_WITH_PROJECTION % "table",
+            "distributed_people_with_projection.sql": PEOPLE_MODEL_WITH_PROJECTION % "distributed_table",
+        }
+
+    @pytest.mark.parametrize("materialization", ("table", "distributed"))
+    def test_create_and_verify_projection(self, project, materialization):
+        run_dbt(["seed"])
+        run_dbt()
+        model_name = "people_with_projection" if materialization == "table" else "distributed_people_with_projection"
+        relation = relation_from_name(project.adapter, model_name)
+
+        query = f"SELECT department, avg(age) AS avg_age FROM {project.test_schema}.{relation.name} GROUP BY department ORDER BY department"
+
+        # Check that the projection works as expected
+        result = project.run_sql(query,
+                                 fetch="all")
+        assert len(result) == 3  # We expect 3 departments in the result
+        assert result == [('engineering', 43.666666666666664), ('malware', 40.0), ('sales', 25.0)]
+
+        # waiting for system.log table to be created
+        time.sleep(10)
+
+        # check that the latest query used the projection
+        result = project.run_sql(
+            f"SELECT query, projections FROM system.query_log WHERE query like '%{query}%' ORDER BY query_start_time DESC",
+            fetch="all")
+        assert len(result) > 0
+        assert query in result[0][0]
+
+        projection_name = f'{project.test_schema}.{relation.name}.projection_avg_age' if materialization == "table" \
+            else f'{project.test_schema}.{relation.name}_local.projection_avg_age'
+
+        assert result[0][1] == [projection_name]


### PR DESCRIPTION
## Summary
close #319 

This PR introduces support for projections in `dbt-clickhouse`. Projections are added to the `table` and `distributed_table` materializations as a model setting. For distributed tables, the projection is applied to the `_local` tables, not to the distributed proxy table.

## Tests
I added a test for each materialization. During test development, I encountered two challenges:

1. To verify that the projection was used by the query, we need to query `system.query_log`. However, this table takes time to create, which necessitates adding a sleep statement.
2. Currently, there's no straightforward way to pass a `query_id` parameter to ClickHouse, making it difficult to retrieve the exact query I want to check. As a workaround, I queried `system.query_log` using a `LIKE` statement.
