### PR TITLE
feat: support range based dictionary layouts

### DIFF
--- a/dbt/include/clickhouse/macros/materializations/dictionary.sql
+++ b/dbt/include/clickhouse/macros/materializations/dictionary.sql
@@ -71,6 +71,9 @@
   )
   LAYOUT({{ config.get('layout') }})
   LIFETIME({{ config.get('lifetime') }})
+  {%- if config.get('range') %}
+  RANGE({{ config.get('range') }})
+  {%- endif %}
 {% endmacro %}
 
 


### PR DESCRIPTION
The [range_hashed](https://clickhouse.com/docs/en/sql-reference/dictionaries#range_hashed) and [complex_key_range_hashed](https://clickhouse.com/docs/en/sql-reference/dictionaries#complex_key_range_hashed) dictionary layouts require a value is set for `RANGE` in the ddl. This PR checks the model config for the `range` key and sets one if provided by the materialization.