### PR TITLE
Allow multiple materialized views to write to same target (#280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Improvement
 * Added support for [range_hashed](https://clickhouse.com/docs/en/sql-reference/dictionaries#range_hashed) and [complex_key_range_hashed](https://clickhouse.com/docs/en/sql-reference/dictionaries#complex_key_range_hashed) layouts to the dictionary materialization. ([#361](https://github.com/ClickHouse/dbt-clickhouse/pull/361))
 
+### New Features
+* Added support for the creation of more than one materialized view inserting records into the same target table. ([#360](https://github.com/ClickHouse/dbt-clickhouse/pull/364))
+
 ### Release [1.8.4], 2024-09-17
 ### Improvement
 * The S3 help macro now support a `role_arn` parameter as an alternative way to provide authentication for S3 based models.  Thanks to

--- a/README.md
+++ b/README.md
@@ -246,6 +246,21 @@ no corresponding REFRESH operation).  Instead, it acts as an "insert trigger", a
 (https://github.com/ClickHouse/dbt-clickhouse/blob/main/tests/integration/adapter/materialized_view/test_materialized_view.py)  for an introductory example
 of how to use this functionality.
 
+Clickhouse provides the ability for more than one materialized view to write records to the same target table. To support this in dbt-clickhouse, you can construct a `UNION` in your model file, such that the SQL for each of your materialized views is wrapped with comments of the form `--my_mv_name:begin` and `--my_mv_name:end`.
+
+For example the following will build two materialized views both writing data to the same destination table of the model. The names of the materialized views will take the form `<model_name>_mv1` and `<model_name>_mv2` :
+
+```
+--mv1:begin
+select a,b,c from {{ source('raw', 'table_1') }}
+--mv1:end
+union all
+--mv2:begin
+select a,b,c from {{ source('raw', 'table_2') }}
+--mv2:end
+```
+
+
 # Dictionary materializations (experimental)
 See the tests in https://github.com/ClickHouse/dbt-clickhouse/blob/main/tests/integration/adapter/dictionary/test_dictionary.py for examples of how to
 implement materializations for ClickHouse dictionaries 

--- a/README.md
+++ b/README.md
@@ -260,6 +260,12 @@ select a,b,c from {{ source('raw', 'table_2') }}
 --mv2:end
 ```
 
+> IMPORTANT!  
+> 
+> When updating a model with multiple materialized views (MVs), especially when renaming one of the MV names, dbt-clickhouse does not automatically drop the old MV. Instead,
+> you will encounter the following warning: `Warning - Table <previous table name> was detected with the same pattern as model name <your model name> but was not found in this run. In case it is a renamed mv that was previously part of this model, drop it manually (!!!) `
+ 
+
 
 # Dictionary materializations (experimental)
 See the tests in https://github.com/ClickHouse/dbt-clickhouse/blob/main/tests/integration/adapter/dictionary/test_dictionary.py for examples of how to

--- a/dbt/include/clickhouse/macros/materializations/materialized_view.sql
+++ b/dbt/include/clickhouse/macros/materializations/materialized_view.sql
@@ -78,7 +78,7 @@
         {{ log('Model mvs to replace ' + mv_names | string) }}
         {% for table in tables %}
             {% if table not in mv_names %}
-                {{ log('Warning - Table "' + table + '" was detected with the same pattern as model name "' + target_relation.name + '" but was not found this run. In case it is a renamed mv that was previously part of this model, drop it manually (!!!)') }}
+                {{ log('Warning - Table "' + table + '" was detected with the same pattern as model name "' + target_relation.name + '" but was not found in this run. In case it is a renamed mv that was previously part of this model, drop it manually (!!!)') }}
             {% endif %}
         {% endfor %}
     {% else %}

--- a/tests/integration/adapter/materialized_view/test_materialized_view.py
+++ b/tests/integration/adapter/materialized_view/test_materialized_view.py
@@ -15,6 +15,9 @@ id,name,age,department
 1231,Dade,33,engineering
 6666,Ksenia,48,engineering
 8888,Kate,50,engineering
+1000,Alfie,10,sales
+2000,Bill,20,sales
+3000,Charlie,30,sales
 """.lstrip()
 
 # This model is parameterized, in a way, by the "run_type" dbt project variable
@@ -40,8 +43,7 @@ select
 from {{ source('raw', 'people') }}
 where department = 'engineering'
 
-{% else %}
-
+{% elif var('run_type', '') == 'extended_schema' %}
 select
     id,
     name,
@@ -54,6 +56,33 @@ select
     end as hacker_alias
 from {{ source('raw', 'people') }}
 where department = 'engineering'
+
+{% elif var('run_type', '') == 'multiple_materialized_views' %}
+
+--mv1:begin
+select
+    id,
+    name,
+    case
+        when name like 'Dade' then 'crash_override'
+        when name like 'Kate' then 'acid burn'
+        else 'N/A'
+    end as hacker_alias
+from {{ source('raw', 'people') }}
+where department = 'engineering'
+--mv1:end
+
+union all
+
+--mv2:begin
+select
+    id,
+    name,
+    -- sales people are not cool enough to have a hacker alias
+    'N/A' as hacker_alias
+from {{ source('raw', 'people') }}
+where department = 'sales'
+--mv2:end
 
 {% endif %}
 """
@@ -191,3 +220,78 @@ class TestUpdateMV:
             f"select distinct hacker_alias from {schema}.hackers where name = 'Dade'", fetch="all"
         )
         assert len(result) == 2
+
+
+class TestMultipleMV:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        """
+        we need a base table to pull from
+        """
+        return {
+            "people.csv": PEOPLE_SEED_CSV,
+            "schema.yml": SEED_SCHEMA_YML,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "hackers.sql": MV_MODEL,
+        }
+
+    def test_create(self, project):
+        """
+        1. create a base table via dbt seed
+        2. create a model as a materialized view, selecting from the table created in (1)
+        3. insert data into the base table and make sure it's there in the target table created in (2)
+        """
+        schema = quote_identifier(project.test_schema + "_custom_schema")
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+        columns = project.run_sql("DESCRIBE TABLE people", fetch="all")
+        assert columns[0][1] == "Int32"
+
+        # create the model
+        run_vars = {"run_type": "multiple_materialized_views"}
+        run_dbt(["run", "--vars", json.dumps(run_vars)])
+        assert len(results) == 1
+
+        columns = project.run_sql(f"DESCRIBE TABLE {schema}.hackers", fetch="all")
+        assert columns[0][1] == "Int32"
+
+        columns = project.run_sql(f"DESCRIBE {schema}.hackers_mv1", fetch="all")
+        assert columns[0][1] == "Int32"
+
+        columns = project.run_sql(f"DESCRIBE {schema}.hackers_mv2", fetch="all")
+        assert columns[0][1] == "Int32"
+
+        with pytest.raises(Exception):
+            columns = project.run_sql(f"DESCRIBE {schema}.hackers_mv", fetch="all")
+
+        check_relation_types(
+            project.adapter,
+            {
+                "hackers_mv": "view",
+                "hackers": "table",
+            },
+        )
+
+        # insert some data and make sure it reaches the target table
+        project.run_sql(
+            f"""
+        insert into {quote_identifier(project.test_schema)}.people ("id", "name", "age", "department")
+            values (4000,'Dave',40,'sales'), (9999,'Eugene',40,'engineering');
+        """
+        )
+
+        result = project.run_sql(f"select * from {schema}.hackers order by id", fetch="all")
+        assert result == [
+            (1000, 'Alfie', 'N/A'),
+            (1231, 'Dade', 'crash_override'),
+            (2000, 'Bill', 'N/A'),
+            (3000, 'Charlie', 'N/A'),
+            (4000, 'Dave', 'N/A'),
+            (6666, 'Ksenia', 'N/A'),
+            (8888, 'Kate', 'acid burn'),
+            (9999, 'Eugene', 'N/A'),
+        ]

--- a/tests/integration/adapter/materialized_view/test_materialized_view.py
+++ b/tests/integration/adapter/materialized_view/test_materialized_view.py
@@ -372,7 +372,8 @@ class TestUpdateMultipleMV:
 
         # assert that we now have both of Dade's aliases in our hackers table
         result = project.run_sql(
-            f"select distinct hacker_alias from {schema}.hackers where name = 'Dade' order by hacker_alias", fetch="all"
+            f"select distinct hacker_alias from {schema}.hackers where name = 'Dade' order by hacker_alias",
+            fetch="all",
         )
         assert len(result) == 2
         assert result[0][0] == "crash_override"
@@ -397,7 +398,8 @@ class TestUpdateMultipleMV:
 
         # assert that we now have both of Dade's aliases in our hackers table
         result = project.run_sql(
-            f"select distinct hacker_alias from {schema}.hackers where name = 'Dade' order by hacker_alias", fetch="all"
+            f"select distinct hacker_alias from {schema}.hackers where name = 'Dade' order by hacker_alias",
+            fetch="all",
         )
         print(result)
         assert len(result) == 2


### PR DESCRIPTION
## Summary
Proposed mechanism to support having multiple materialized views pointing to the same target table.

In brief, we add tags to mark blocks of the sql which will form each of the materialized views to be created. 

i.e. https://github.com/ClickHouse/dbt-clickhouse/pull/364/files#diff-b1cddf2e5c9b3d08ea2276e5cef4944b06b9744a4076c5970ff5a5edb0140f08R62.

The entire union of all such blocks is used to backfill the target table.

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [x] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
