### PR TITLE
Dont drop tables in incremental append runs

### DIFF
--- a/dbt/include/clickhouse/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/clickhouse/macros/materializations/incremental/incremental.sql
@@ -22,7 +22,7 @@
   {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}
   {% set incremental_strategy = adapter.calculate_incremental_strategy(config.get('incremental_strategy'))  %}
   
-  {% if not full_refresh_mode and incremental_strategy == 'append' %}
+  {% if not full_refresh_mode and incremental_strategy == 'append' and config.get('incremental_append_skip_drop_table', default='false') == 'true' %}
     -- skip dropping tables for incremental append runs.
   {% else %}
     {{ drop_relation_if_exists(preexisting_intermediate_relation) }}


### PR DESCRIPTION
Hi, when dbt runs for a incremental+append it always drops the temporary tables that are used for full refreshes. Even if its not going to use them.

In my system, I have scheduled incremental runs of dbt that run frequently updating incremental+append tables. Whenever I do a full refresh (concurrently), the scheduled run drops the tables of the full refresh causing it to crash.

This PR stops that, by making the incremental+append runs not drop tables.

I see there have been a few other issues similar to this, but this seems like an easy minimal way to fix the issue.

- https://github.com/ClickHouse/dbt-clickhouse/issues/150
- https://github.com/ClickHouse/dbt-clickhouse/pull/353

Thanks