### PR TITLE
Atomic view creation in view.sql

### DIFF
--- a/dbt/include/clickhouse/macros/materializations/view.sql
+++ b/dbt/include/clickhouse/macros/materializations/view.sql
@@ -1,52 +1,15 @@
 {%- materialization view, adapter='clickhouse' -%}
 
-  {%- set existing_relation = load_cached_relation(this) -%}
-  {%- set target_relation = this.incorporate(type='view') -%}
-  {%- set backup_relation = none -%}
-  {%- set preexisting_backup_relation = none -%}
-  {%- set preexisting_intermediate_relation = none -%}
-
-  {% if existing_relation is not none %}
-    {%- set backup_relation_type = existing_relation.type -%}
-    {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}
-    {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}
-    {% if not existing_relation.can_exchange %}
-      {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}
-      {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}
-    {% endif %}
-  {% endif %}
-
   {% set grant_config = config.get('grants') %}
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
-  -- drop the temp relations if they exist already in the database
-  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
-  {{ drop_relation_if_exists(preexisting_backup_relation) }}
-
   -- `BEGIN` happens here:
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
-
-  {% if backup_relation is none %}
-    {{ log('Creating new relation ' + target_relation.name )}}
-    -- There is not existing relation, so we can just create
-    {% call statement('main') -%}
-      {{ get_create_view_as_sql(target_relation, sql) }}
-    {%- endcall %}
-  {% elif existing_relation.can_exchange %}
-    -- We can do an atomic exchange, so no need for an intermediate
-    {% call statement('main') -%}
-      {{ get_create_view_as_sql(backup_relation, sql) }}
-    {%- endcall %}
-    {% do exchange_tables_atomic(backup_relation, existing_relation) %}
-  {% else %}
-    -- We have to use an intermediate and rename accordingly
-    {% call statement('main') -%}
-      {{ get_create_view_as_sql(intermediate_relation, sql) }}
-    {%- endcall %}
-    {{ adapter.rename_relation(existing_relation, backup_relation) }}
-    {{ adapter.rename_relation(intermediate_relation, target_relation) }}
-  {% endif %}
+  {{ log('Creating new relation ' + target_relation.name )}}
+  {% call statement('main') -%}
+    {{ get_create_view_as_sql(target_relation, sql) }}
+  {%- endcall %}
 
   -- cleanup
   {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}
@@ -57,8 +20,6 @@
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 
   {{ adapter.commit() }}
-
-  {{ drop_relation_if_exists(backup_relation) }}
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 
@@ -71,7 +32,7 @@
   {%- set sql_header = config.get('sql_header', none) -%}
   {{ sql_header if sql_header is not none }}
 
-  create view {{ relation.include(database=False) }} {{ on_cluster_clause(relation)}}
+  create or replace view {{ relation.include(database=False) }} {{ on_cluster_clause(relation)}}
     {% set contract_config = config.get('contract') %}
     {% if contract_config.enforced %}
       {{ get_assert_columns_equivalent(sql) }}


### PR DESCRIPTION
This PR changes the view creation to use `create or replace view`, which is atomic.

Previously, dbt-clickhouse would:
1. Create a new "temporary" view
2. Drop the current view (eek!)
3. Rename the new view to the current view

The above 3 steps aren't done in a single transactions, so any queries on the view that occur during the process may get errors that the view doesn't exist.

Ideally, the operations are done in a single, atomic operation. I.e. use `create or replace view`.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
