### PR TITLE
Add list support to `primary_key`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Unreleased
+### Improvement
+
+* Enhance the `primary_key` macro to accept a list of columns, allowing for primary keys with multiple columns. ([#337](https://github.com/ClickHouse/dbt-clickhouse/pull/337))
+
 ### Release [1.8.4], 2024-09-17
 ### Improvement
 * The S3 help macro now support a `role_arn` parameter as an alternative way to provide authentication for S3 based models.  Thanks to

--- a/dbt/include/clickhouse/macros/materializations/table.sql
+++ b/dbt/include/clickhouse/macros/materializations/table.sql
@@ -86,10 +86,18 @@
 {%- endmacro -%}
 
 {% macro primary_key_clause(label) %}
-  {%- set primary_key = config.get('primary_key', validator=validation.any[basestring]) -%}
+  {%- set cols = config.get('primary_key', validator=validation.any[list, basestring]) -%}
 
-  {%- if primary_key is not none %}
-    {{ label }} {{ primary_key }}
+  {%- if cols is not none %}
+    {%- if cols is string -%}
+      {%- set cols = [cols] -%}
+    {%- endif -%}
+    {{ label }} (
+    {%- for item in cols -%}
+      {{ item }}
+      {%- if not loop.last -%},{%- endif -%}
+    {%- endfor -%}
+    )
   {%- endif %}
 {%- endmacro -%}
 

--- a/tests/integration/adapter/basic/test_incremental.py
+++ b/tests/integration/adapter/basic/test_incremental.py
@@ -7,7 +7,7 @@ class TestIncremental(BaseIncremental):
 
 
 incremental_not_schema_change_sql = """
-{{ config(materialized="incremental", unique_key="user_id_current_time",on_schema_change="append_new_columns") }}
+{{ config(materialized="incremental", primary_key="user_id_current_time", unique_key="user_id_current_time",on_schema_change="append_new_columns") }}
 select
     toString(1) || '-' || toString(now64()) as user_id_current_time,
     {% if is_incremental() %}

--- a/tests/integration/adapter/clickhouse/test_clickhouse_s3.py
+++ b/tests/integration/adapter/clickhouse/test_clickhouse_s3.py
@@ -36,6 +36,7 @@ s3_taxis_inc = """
     materialized='incremental',
     order_by='pickup_datetime',
     incremental_strategy='delete+insert',
+    primary_key='trip_id',
     unique_key='trip_id',
     taxi_s3={"structure":['trip_id UInt32', 'pickup_datetime DateTime', 'passenger_count UInt8']}
     )

--- a/tests/integration/adapter/incremental/test_base_incremental.py
+++ b/tests/integration/adapter/incremental/test_base_incremental.py
@@ -20,6 +20,7 @@ uniq_source_model = """
         materialized='table',
         engine='MergeTree()',
         order_by=['ts'],
+        primary_key=['impid'],
         unique_key=['impid']
     )
 }}
@@ -33,6 +34,7 @@ uniq_incremental_model = """
         materialized='incremental',
         engine='MergeTree()',
         order_by=['ts'],
+        primary_key=['impid'],
         unique_key=['impid'],
         settings={'allow_nullable_key':'1'}
     )
@@ -62,6 +64,7 @@ lw_delete_inc = """
 {{ config(
         materialized='incremental',
         order_by=['key1'],
+        primary_key='key1',
         unique_key='key1',
         incremental_strategy='delete+insert',
         settings={'allow_nullable_key':1}
@@ -97,6 +100,7 @@ legacy_inc = """
 {{ config(
         materialized='incremental',
         order_by=['key1'],
+        primary_key='key1',
         unique_key='key1',
         incremental_strategy='legacy',
         settings={'allow_nullable_key':1}
@@ -140,6 +144,7 @@ compound_key_inc = """
 {{ config(
         materialized='incremental',
         order_by=['key1', 'key2'],
+        primary_key=['key1', 'key2'],
         unique_key='key1, key2',
         incremental_strategy='delete+insert'
     )
@@ -174,7 +179,7 @@ class TestInsertsOnlyIncrementalMaterialization(BaseIncremental):
     @pytest.fixture(scope="class")
     def models(self):
         config_materialized_incremental = """
-          {{ config(order_by='(some_date, id, name)', inserts_only=True, materialized='incremental', unique_key='id') }}
+          {{ config(order_by='(some_date, id, name)', inserts_only=True, materialized='incremental', primary_key='id', unique_key='id') }}
         """
         incremental_sql = config_materialized_incremental + model_incremental
         return {

--- a/tests/integration/adapter/incremental/test_distributed_incremental.py
+++ b/tests/integration/adapter/incremental/test_distributed_incremental.py
@@ -17,6 +17,7 @@ uniq_source_model = """
         materialized='distributed_table',
         engine='MergeTree()',
         order_by=['ts'],
+        primary_key=['impid'],
         unique_key=['impid']
     )
 }}
@@ -29,6 +30,7 @@ uniq_incremental_model = """
     config(
         materialized='distributed_incremental',
         engine='MergeTree()',
+        primary_key=['impid'],
         order_by=['ts'],
         unique_key=['impid']
     )
@@ -69,6 +71,7 @@ lw_delete_inc = """
 {{ config(
         materialized='distributed_incremental',
         order_by=['key1'],
+        primary_key='key1',
         unique_key='key1',
         incremental_strategy='delete+insert'
     )
@@ -111,6 +114,7 @@ compound_key_inc = """
 {{ config(
         materialized='distributed_incremental',
         order_by=['key1', 'key2'],
+        primary_key=['key1', 'key2'],
         unique_key='key1, key2',
         incremental_strategy='delete+insert'
     )
@@ -158,7 +162,7 @@ class TestInsertsOnlyDistributedIncrementalMaterialization(BaseIncremental):
     @pytest.fixture(scope="class")
     def models(self):
         config_materialized_incremental = """
-          {{ config(order_by='(some_date, id, name)', inserts_only=True, materialized='distributed_incremental', unique_key='id') }}
+          {{ config(order_by='(some_date, id, name)', inserts_only=True, materialized='distributed_incremental', primary_key='id', unique_key='id') }}
         """
         incremental_sql = config_materialized_incremental + model_incremental
         return {
@@ -182,7 +186,7 @@ class TestInsertsOnlyDistributedIncrementalMaterialization(BaseIncremental):
 
 
 incremental_not_schema_change_sql = """
-{{ config(materialized="distributed_incremental", unique_key="user_id_current_time",on_schema_change="sync_all_columns") }}
+{{ config(materialized="distributed_incremental", primary_key="user_id_current_time", unique_key="user_id_current_time", on_schema_change="sync_all_columns") }}
 select
     toString(1) || '-' || toString(now64()) as user_id_current_time,
     {% if is_incremental() %}

--- a/tests/integration/adapter/incremental/test_schema_change.py
+++ b/tests/integration/adapter/incremental/test_schema_change.py
@@ -8,6 +8,7 @@ schema_change_sql = """
 {{
     config(
         materialized='%s',
+        primary_key='col_1',
         unique_key='col_1',
         on_schema_change='%s'
     )
@@ -101,6 +102,7 @@ complex_schema_change_sql = """
 {{
     config(
         materialized='%s',
+        primary_key='col_1',
         unique_key='col_1',
         on_schema_change='%s'
     )
@@ -189,6 +191,7 @@ out_of_order_columns_sql = """
 {{
     config(
         materialized='%s',
+        primary_key='col_1',
         unique_key='col_1',
         on_schema_change='fail'
     )


### PR DESCRIPTION
## Summary

Enhance the `primary_key` macro to accept a list of columns, allowing for primary keys with multiple columns. This improves flexibility in configuration.

With this PR it's now possible to do the following:
```sql
{{
    config(
        primary_key=['a', 'b'],
        order_by=['a', 'b'],
    )
}}
-- ...
```

Before, you would need to use the literal expression as follows `primary_key='(a, b)'`

## Checklist
<!-- Delete items not relevant to your PR: -->
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [x] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
