### PR TITLE
Remove stacktrace from database errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
 ### Improvement
 * Added support for [range_hashed](https://clickhouse.com/docs/en/sql-reference/dictionaries#range_hashed) and [complex_key_range_hashed](https://clickhouse.com/docs/en/sql-reference/dictionaries#complex_key_range_hashed) layouts to the dictionary materialization. ([#361](https://github.com/ClickHouse/dbt-clickhouse/pull/361))
+* Truncated stack trace for database errors for cleaner output
 
 ### Release [1.8.4], 2024-09-17
 ### Improvement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Unreleased
 ### Improvement
 * Added support for [range_hashed](https://clickhouse.com/docs/en/sql-reference/dictionaries#range_hashed) and [complex_key_range_hashed](https://clickhouse.com/docs/en/sql-reference/dictionaries#complex_key_range_hashed) layouts to the dictionary materialization. ([#361](https://github.com/ClickHouse/dbt-clickhouse/pull/361))
-* Truncated stack trace for database errors for cleaner output
+* Truncated stack trace for database errors for cleaner output when HIDE_STACK_TRACE variable is set to any value.
 
 ### Release [1.8.4], 2024-09-17
 ### Improvement

--- a/dbt/adapters/clickhouse/httpclient.py
+++ b/dbt/adapters/clickhouse/httpclient.py
@@ -15,7 +15,8 @@ class ChHttpClient(ChClientWrapper):
         try:
             return self._client.query(sql, **kwargs)
         except DatabaseError as ex:
-            raise DbtDatabaseError(str(ex).strip()) from ex
+            err_msg = str(ex).strip().split("Stack trace")[0]
+            raise DbtDatabaseError(err_msg) from ex
 
     def command(self, sql, **kwargs):
         try:
@@ -35,7 +36,8 @@ class ChHttpClient(ChClientWrapper):
                 for name, ch_type in zip(query_result.column_names, query_result.column_types)
             ]
         except DatabaseError as ex:
-            raise DbtDatabaseError(str(ex).strip()) from ex
+            err_msg = str(ex).strip().split("Stack trace")[0]
+            raise DbtDatabaseError(err_msg) from ex
 
     def get_ch_setting(self, setting_name):
         setting = self._client.server_settings.get(setting_name)

--- a/dbt/adapters/clickhouse/httpclient.py
+++ b/dbt/adapters/clickhouse/httpclient.py
@@ -21,7 +21,8 @@ class ChHttpClient(ChClientWrapper):
         try:
             return self._client.command(sql, **kwargs)
         except DatabaseError as ex:
-            raise DbtDatabaseError(str(ex).strip()) from ex
+            err_msg = str(ex).strip().split("Stack trace")[0]
+            raise DbtDatabaseError(err_msg) from ex
 
     def columns_in_query(self, sql: str, **kwargs) -> List[ClickHouseColumn]:
         try:

--- a/dbt/adapters/clickhouse/httpclient.py
+++ b/dbt/adapters/clickhouse/httpclient.py
@@ -8,6 +8,7 @@ from dbt_common.exceptions import DbtDatabaseError
 from dbt.adapters.clickhouse import ClickHouseColumn
 from dbt.adapters.clickhouse.__version__ import version as dbt_clickhouse_version
 from dbt.adapters.clickhouse.dbclient import ChClientWrapper, ChRetryableException
+from dbt.adapters.clickhouse.util import hide_stack_trace
 
 
 class ChHttpClient(ChClientWrapper):
@@ -15,14 +16,14 @@ class ChHttpClient(ChClientWrapper):
         try:
             return self._client.query(sql, **kwargs)
         except DatabaseError as ex:
-            err_msg = str(ex).strip().split("Stack trace")[0]
+            err_msg = hide_stack_trace(ex)
             raise DbtDatabaseError(err_msg) from ex
 
     def command(self, sql, **kwargs):
         try:
             return self._client.command(sql, **kwargs)
         except DatabaseError as ex:
-            err_msg = str(ex).strip().split("Stack trace")[0]
+            err_msg = hide_stack_trace(ex)
             raise DbtDatabaseError(err_msg) from ex
 
     def columns_in_query(self, sql: str, **kwargs) -> List[ClickHouseColumn]:
@@ -36,7 +37,7 @@ class ChHttpClient(ChClientWrapper):
                 for name, ch_type in zip(query_result.column_names, query_result.column_types)
             ]
         except DatabaseError as ex:
-            err_msg = str(ex).strip().split("Stack trace")[0]
+            err_msg = hide_stack_trace(ex)
             raise DbtDatabaseError(err_msg) from ex
 
     def get_ch_setting(self, setting_name):

--- a/dbt/adapters/clickhouse/nativeclient.py
+++ b/dbt/adapters/clickhouse/nativeclient.py
@@ -10,6 +10,7 @@ from dbt.adapters.clickhouse import ClickHouseColumn, ClickHouseCredentials
 from dbt.adapters.clickhouse.__version__ import version as dbt_clickhouse_version
 from dbt.adapters.clickhouse.dbclient import ChClientWrapper, ChRetryableException
 from dbt.adapters.clickhouse.logger import logger
+from dbt.adapters.clickhouse.util import hide_stack_trace
 
 try:
     driver_version = pkg_resources.get_distribution('clickhouse-driver').version
@@ -22,7 +23,7 @@ class ChNativeClient(ChClientWrapper):
         try:
             return NativeClientResult(self._client.execute(sql, with_column_types=True, **kwargs))
         except clickhouse_driver.errors.Error as ex:
-            err_msg = str(ex).strip().split("Stack trace")[0]
+            err_msg = hide_stack_trace(ex)
             raise DbtDatabaseError(err_msg) from ex
 
     def command(self, sql, **kwargs):
@@ -31,7 +32,7 @@ class ChNativeClient(ChClientWrapper):
             if len(result) and len(result[0]):
                 return result[0][0]
         except clickhouse_driver.errors.Error as ex:
-            err_msg = str(ex).strip().split("Stack trace")[0]
+            err_msg = hide_stack_trace(ex)
             raise DbtDatabaseError(err_msg) from ex
 
     def columns_in_query(self, sql: str, **kwargs) -> List[ClickHouseColumn]:
@@ -42,7 +43,7 @@ class ChNativeClient(ChClientWrapper):
             )
             return [ClickHouseColumn.create(column[0], column[1]) for column in columns]
         except clickhouse_driver.errors.Error as ex:
-            err_msg = str(ex).strip().split("Stack trace")[0]
+            err_msg = hide_stack_trace(ex)
             raise DbtDatabaseError(err_msg) from ex
 
     def get_ch_setting(self, setting_name):

--- a/dbt/adapters/clickhouse/nativeclient.py
+++ b/dbt/adapters/clickhouse/nativeclient.py
@@ -30,7 +30,8 @@ class ChNativeClient(ChClientWrapper):
             if len(result) and len(result[0]):
                 return result[0][0]
         except clickhouse_driver.errors.Error as ex:
-            raise DbtDatabaseError(str(ex).strip()) from ex
+            err_msg = str(ex).strip().split("Stack trace")[0]
+            raise DbtDatabaseError(err_msg) from ex
 
     def columns_in_query(self, sql: str, **kwargs) -> List[ClickHouseColumn]:
         try:

--- a/dbt/adapters/clickhouse/nativeclient.py
+++ b/dbt/adapters/clickhouse/nativeclient.py
@@ -22,7 +22,8 @@ class ChNativeClient(ChClientWrapper):
         try:
             return NativeClientResult(self._client.execute(sql, with_column_types=True, **kwargs))
         except clickhouse_driver.errors.Error as ex:
-            raise DbtDatabaseError(str(ex).strip()) from ex
+            err_msg = str(ex).strip().split("Stack trace")[0]
+            raise DbtDatabaseError(err_msg) from ex
 
     def command(self, sql, **kwargs):
         try:
@@ -41,7 +42,8 @@ class ChNativeClient(ChClientWrapper):
             )
             return [ClickHouseColumn.create(column[0], column[1]) for column in columns]
         except clickhouse_driver.errors.Error as ex:
-            raise DbtDatabaseError(str(ex).strip()) from ex
+            err_msg = str(ex).strip().split("Stack trace")[0]
+            raise DbtDatabaseError(err_msg) from ex
 
     def get_ch_setting(self, setting_name):
         try:

--- a/dbt/adapters/clickhouse/util.py
+++ b/dbt/adapters/clickhouse/util.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+import os
 
 from dbt_common.exceptions import DbtRuntimeError
 
@@ -13,3 +13,12 @@ def compare_versions(v1: str, v2: str) -> int:
         except ValueError:
             raise DbtRuntimeError("Version must consist of only numbers separated by '.'")
     return 0
+
+
+def hide_stack_trace(ex: Exception) -> str:
+
+    if not os.getenv("HIDE_STACK_TRACE", ''):
+        return str(ex).strip()
+
+    err_msg = str(ex).split("Stack trace")[0].strip()
+    return err_msg

--- a/tests/integration/adapter/dictionary/test_dictionary.py
+++ b/tests/integration/adapter/dictionary/test_dictionary.py
@@ -6,7 +6,6 @@ import json
 import os
 
 import pytest
-
 from dbt.tests.util import run_dbt
 
 testing_s3 = os.environ.get('DBT_CH_TEST_INCLUDE_S3', '').lower() in ('1', 'true', 'yes')

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,4 +1,6 @@
-from dbt.adapters.clickhouse.util import compare_versions
+from unittest.mock import patch
+
+from dbt.adapters.clickhouse.util import compare_versions, hide_stack_trace
 
 
 def test_is_before_version():
@@ -11,3 +13,19 @@ def test_is_before_version():
     assert compare_versions('22.0.0', '21.0.0') == 1
     assert compare_versions('21.0.1', '21.0.0') == 1
     assert compare_versions('21.0.1', '21.0') == 0
+
+
+def test_hide_stack_trace_no_env_var():
+    # Test when HIDE_STACK_TRACE is not set
+    with patch('os.getenv', return_value=''):
+        exception = Exception("Error occurred\nStack trace details follow...")
+        result = hide_stack_trace(exception)
+        assert result == "Error occurred\nStack trace details follow..."
+
+
+def test_hide_stack_trace_env_var_set():
+    # Test when HIDE_STACK_TRACE is set
+    with patch('os.getenv', return_value='1'):
+        exception = Exception("Error occurred\nStack trace details follow...")
+        result = hide_stack_trace(exception)
+        assert result == "Error occurred"


### PR DESCRIPTION
## Summary
I'm always frustrated when scrolling throw stack trace to my actual errors in database.

#381 

**Solution**
Remove stack trace and keep only database errors.

**Before**
```
clickhouse adapter: ClickHouse server does not support exchange tables Database Error
  Code: 1.
  DB::Exception: System call renameat2() is not supported. Stack trace:
  
  0. DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool) @ 0xce3f35a in /usr/bin/clickhouse
  1. DB::renameExchange(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) @ 0x11a385a5 in /usr/bin/clickhouse
  2. DB::DatabaseAtomic::renameTable(std::__1::shared_ptr<DB::Context const>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, DB::IDatabase&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, bool) @ 0x11a2f0dd in /usr/bin/clickhouse
  3. DB::InterpreterRenameQuery::executeToTables(DB::ASTRenameQuery const&, std::__1::vector<DB::RenameDescription, std::__1::allocator<DB::RenameDescription> > const&, std::__1::map<DB::UniqueTableName, std::__1::unique_ptr<DB::DDLGuard, std::__1::default_delete<DB::DDLGuard> >, std::__1::less<DB::UniqueTableName>, std::__1::allocator<std::__1::pair<DB::UniqueTableName const, std::__1::unique_ptr<DB::DDLGuard, std::__1::default_delete<DB::DDLGuard> > > > >&) @ 0x125ca713 in /usr/bin/clickhouse
  4. DB::InterpreterRenameQuery::execute() @ 0x125c9608 in /usr/bin/clickhouse
  5. ? @ 0x1297956b in /usr/bin/clickhouse
  6. DB::executeQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::shared_ptr<DB::Context>, bool, DB::QueryProcessingStage::Enum) @ 0x1297682d in /usr/bin/clickhouse
  7. DB::TCPHandler::runImpl() @ 0x1353d924 in /usr/bin/clickhouse
  8. DB::TCPHandler::run() @ 0x13551919 in /usr/bin/clickhouse
  9. Poco::Net::TCPServerConnection::start() @ 0x1636236f in /usr/bin/clickhouse
  10. Poco::Net::TCPServerDispatcher::run() @ 0x163646fb in /usr/bin/clickhouse
  11. Poco::PooledThread::run() @ 0x1651ff92 in /usr/bin/clickhouse
  12. Poco::ThreadImpl::runnableEntry(void*) @ 0x1651d71d in /usr/bin/clickhouse
  13. ? @ 0x7fd8e7797609 in ?
  14. clone @ 0x7fd8e76bc133 in ?
```

**After**
```
clickhouse adapter: ClickHouse server does not support exchange tables Database Error
  Code: 1.
  DB::Exception: System call renameat2() is not supported.
```

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
