### PR TITLE
Support of insert_overwrite in cluster setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Added support for [range_hashed](https://clickhouse.com/docs/en/sql-reference/dictionaries#range_hashed) and [complex_key_range_hashed](https://clickhouse.com/docs/en/sql-reference/dictionaries#complex_key_range_hashed) layouts to the dictionary materialization. ([#361](https://github.com/ClickHouse/dbt-clickhouse/pull/361))
 * Truncated stack trace for database errors for cleaner output when HIDE_STACK_TRACE variable is set to any value. ([#382](https://github.com/ClickHouse/dbt-clickhouse/pull/382))
 * It is now possible to pass query settings not only on table creation but also on query. ([#362](https://github.com/ClickHouse/dbt-clickhouse/pull/362))
+* Added Support of insert_overwrite in cluster setup with incremental and distributed_incremental materializations ([#394](https://github.com/ClickHouse/dbt-clickhouse/pull/394))
+
 
 ### Bug Fixes
 * Before this version, `split_part` macro used to add an extra quotation. that was fixed in ([#338](https://github.com/ClickHouse/dbt-clickhouse/pull/338))

--- a/tests/integration/adapter/incremental/test_base_incremental.py
+++ b/tests/integration/adapter/incremental/test_base_incremental.py
@@ -195,7 +195,7 @@ insert_overwrite_inc = """
     SELECT partitionKey1, partitionKey2, orderKey, value
     FROM VALUES(
         'partitionKey1 UInt8, partitionKey2 String, orderKey UInt8, value String',
-        (1, 'p1', 1, 'a'), (1, 'p1', 1, 'b'), (2, 'p1', 1, 'c'), (2, 'p2', 1, 'd')
+        (1, 'p1', 1, 'a'), (1, 'p1', 2, 'b'), (2, 'p1', 3, 'c'), (2, 'p2', 4, 'd')
     )
 {% else %}
     SELECT partitionKey1, partitionKey2, orderKey, value
@@ -207,7 +207,7 @@ insert_overwrite_inc = """
 """
 
 
-class TestInsertReplaceIncremental:
+class TestInsertOverwriteIncremental:
     @pytest.fixture(scope="class")
     def models(self):
         return {"insert_overwrite_inc.sql": insert_overwrite_inc}
@@ -220,9 +220,9 @@ class TestInsertReplaceIncremental:
         )
         assert result == [
             (1, 'p1', 1, 'a'),
-            (1, 'p1', 1, 'b'),
-            (2, 'p1', 1, 'c'),
-            (2, 'p2', 1, 'd'),
+            (1, 'p1', 2, 'b'),
+            (2, 'p1', 3, 'c'),
+            (2, 'p2', 4, 'd'),
         ]
         run_dbt()
         result = project.run_sql(
@@ -231,7 +231,62 @@ class TestInsertReplaceIncremental:
         )
         assert result == [
             (1, 'p1', 2, 'e'),
-            (2, 'p1', 1, 'c'),
-            (2, 'p2', 1, 'd'),
+            (2, 'p1', 3, 'c'),
+            (2, 'p2', 4, 'd'),
+            (3, 'p1', 2, 'f'),
+        ]
+
+# "ReplicatedMergeTree('/clickhouse/tables/{shard}/{database}/{table}/{uuid}/', '{replica}')"
+insert_overwrite_replicated_inc = """
+{{ config(
+        materialized='incremental',
+        incremental_strategy='insert_overwrite',
+        partition_by=['partitionKey1', 'partitionKey2'],
+        order_by=['orderKey'],
+        engine="ReplicatedMergeTree('/clickhouse/tables/{uuid}/one_shard', '{server_index}')"
+    )
+}}
+{% if not is_incremental() %}
+    SELECT partitionKey1, partitionKey2, orderKey, value
+    FROM VALUES(
+        'partitionKey1 UInt8, partitionKey2 String, orderKey UInt8, value String',
+        (1, 'p1', 1, 'a'), (1, 'p1', 2, 'b'), (2, 'p1', 3, 'c'), (2, 'p2', 4, 'd')
+    )
+{% else %}
+    SELECT partitionKey1, partitionKey2, orderKey, value
+    FROM VALUES(
+        'partitionKey1 UInt8, partitionKey2 String, orderKey UInt8, value String',
+        (1, 'p1', 2, 'e'), (3, 'p1', 2, 'f')
+    )
+{% endif %}
+"""
+
+
+class TestInsertOverwriteReplicatedIncremental:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"insert_overwrite_replicated_inc.sql": insert_overwrite_replicated_inc}
+
+    def test_insert_overwrite_replicated_incremental(self, project):
+        run_dbt()
+        result = project.run_sql(
+            "select * from insert_overwrite_replicated_inc order by partitionKey1, partitionKey2, orderKey",
+            fetch="all",
+        )
+        assert result == [
+            (1, 'p1', 1, 'a'),
+            (1, 'p1', 2, 'b'),
+            (2, 'p1', 3, 'c'),
+            (2, 'p2', 4, 'd'),
+        ]
+        run_dbt()
+        result = project.run_sql(
+            "select * from insert_overwrite_replicated_inc order by partitionKey1, partitionKey2, orderKey",
+            fetch="all",
+        )
+        assert result == [
+            (1, 'p1', 2, 'e'),
+            (2, 'p1', 3, 'c'),
+            (2, 'p2', 4, 'd'),
             (3, 'p1', 2, 'f'),
         ]


### PR DESCRIPTION

## Summary
Support of insert_overwrite in cluster setup with incremental and distributed_incremental materializations

## In details
1) In case is_distributed is True it creates distributed version of new data, gets partitions from cluster(system.parts) and replace in local existing table
2) The intermediate_relation entity was deleted as unnecessary because it is a incremental_legacy remnant. 
3) The existing test for insert_overwrite was renamed and made deterministic  


## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [x] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
