### PR TITLE
Protect against no columns returned in materialized-view (#395)

### DIFF
--- a/dbt/include/clickhouse/macros/materializations/materialized_view.sql
+++ b/dbt/include/clickhouse/macros/materializations/materialized_view.sql
@@ -68,7 +68,7 @@
         {% endset %}
 
     {% set tables_result = run_query(tables_query) %}
-    {% if tables_result is not none %}
+    {% if tables_result is not none and tables_result.columns %}
         {% set tables = tables_result.columns[0].values() %}
         {{ log('Current mvs found in ClickHouse are: ' + tables | join(', ')) }}
         {% set mv_names = [] %}


### PR DESCRIPTION
## Summary

If no rows are returned from the query then referencing element 0 fails.

https://github.com/ClickHouse/dbt-clickhouse/issues/395

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
