### PR TITLE
Support refreshable materialized views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ### Unreleased
 
+### New Features
+* Added support for [refreshable materialized view](https://clickhouse.com/docs/en/materialized-view/refreshable-materialized-view) ([#401](https://github.com/ClickHouse/dbt-clickhouse/pull/401))
 ### Improvement
-
-Avoid potential data loss by using `CREATE OR REPLACE DICTIONARY` to atomically update a dictionary (#393)
+* Avoid potential data loss by using `CREATE OR REPLACE DICTIONARY` to atomically update a dictionary ([#393](https://github.com/ClickHouse/dbt-clickhouse/pull/393))
 
 ### Release [1.8.6], 2024-12-05
 

--- a/README.md
+++ b/README.md
@@ -374,8 +374,11 @@ A config example for refreshable materialized view:
 }}
 ```
 
-> [!IMPORTANT]
-> The refreshable feature was not tested with multiple mvs directing to the same target model.
+### Limitations
+* When creating a refreshable materialized view (MV) in ClickHouse that has a dependency, ClickHouse does not throw an error if the specified dependency does not exist at the time of creation. Instead, the refreshable MV remains in an inactive state, waiting for the dependency to be satisfied before it starts processing updates or refreshing.
+This behavior is by design, but it may lead to delays in data availability if the required dependency is not addressed promptly. Users are advised to ensure all dependencies are correctly defined and exist before creating a refreshable materialized view.
+* As of today, there is no actual "dbt linkage" between the mv and its dependencies, therefore the creation order is not guaranteed.
+* The refreshable feature was not tested with multiple mvs directing to the same target model.
 
 # Dictionary materializations (experimental)
 

--- a/README.md
+++ b/README.md
@@ -6,18 +6,21 @@
 
 This plugin ports [dbt](https://getdbt.com) functionality to [Clickhouse](https://clickhouse.tech/).
 
-The plugin uses syntax that requires ClickHouse version 22.1 or newer. We do not test older versions of Clickhouse.  We also do not currently test
+The plugin uses syntax that requires ClickHouse version 22.1 or newer. We do not test older versions of Clickhouse. We
+also do not currently test
 Replicated tables or the related `ON CLUSTER` functionality.
 
 ## Installation
 
 Use your favorite Python package manager to install the app from PyPI, e.g.
+
 ```bash
 pip install dbt-core dbt-clickhouse
 ```
 
-> **_NOTE:_**  Beginning in v1.8, dbt-core and adapters are decoupled. Therefore, the installation mentioned above explicitly includes both dbt-core and the desired adapter.If you use a version prior to 1.8.0 the pip installation command should look like this:
- 
+> **_NOTE:_**  Beginning in v1.8, dbt-core and adapters are decoupled. Therefore, the installation mentioned above
+> explicitly includes both dbt-core and the desired adapter.If you use a version prior to 1.8.0 the pip installation
+> command should look like this:
 
 ```bash
 pip install dbt-clickhouse
@@ -34,7 +37,7 @@ pip install dbt-clickhouse
 - [x] Docs generate
 - [x] Tests
 - [x] Snapshots
-- [x] Most dbt-utils macros (now included in dbt-core)  
+- [x] Most dbt-utils macros (now included in dbt-core)
 - [x] Ephemeral materialization
 - [x] Distributed table materialization (experimental)
 - [x] Distributed incremental materialization (experimental)
@@ -43,17 +46,20 @@ pip install dbt-clickhouse
 # Usage Notes
 
 ## SET Statement Warning
+
 In many environments, using the SET statement to persist a ClickHouse setting across all DBT queries is not reliable
-and can cause unexpected failures.  This is particularly true when using HTTP connections through a load balancer that
+and can cause unexpected failures. This is particularly true when using HTTP connections through a load balancer that
 distributes queries across multiple nodes (such as ClickHouse cloud), although in some circumstances this can also
-happen with native ClickHouse connections.  Accordingly, we recommend configuring any required ClickHouse settings in the
+happen with native ClickHouse connections. Accordingly, we recommend configuring any required ClickHouse settings in the
 "custom_settings" property of the DBT profile as a best practice, instead of relying on a prehook "SET" statement as
 has been occasionally suggested.
 
 ## Database
 
-The dbt model relation identifier `database.schema.table` is not compatible with Clickhouse because Clickhouse does not support a `schema`.
-So we use a simplified approach `schema.table`, where `schema` is the Clickhouse database. Using the `default` database is not recommended.
+The dbt model relation identifier `database.schema.table` is not compatible with Clickhouse because Clickhouse does not
+support a `schema`.
+So we use a simplified approach `schema.table`, where `schema` is the Clickhouse database. Using the `default` database
+is not recommended.
 
 ## Example Profile
 
@@ -112,112 +118,150 @@ your_profile_name:
 | query_settings         | A map/dictionary of ClickHouse user level settings to be used with `INSERT` or `DELETE` statements in conjunction with this model                                                                                                                                                                                    |                |
 | ttl                    | A TTL expression to be used with the table.  The TTL expression is a string that can be used to specify the TTL for the table.                                                                                                                                                                                       |                |
 
-
 ## Column Configuration
 
 | Option | Description                                                                                                                                                | Default if any |
-| ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------|
 | codec  | A string consisting of arguments passed to `CODEC()` in the column's DDL. For example: `codec: "Delta, ZSTD"` will be interpreted as `CODEC(Delta, ZSTD)`. |                |
 
-## ClickHouse Cluster 
+## ClickHouse Cluster
 
 The `cluster` setting in profile enables dbt-clickhouse to run against a ClickHouse cluster.
 
 ### Effective Scope
 
-
 if `cluster` is set in profile, `on_cluster_clause` now will return cluster info for:
+
 - Database creation
 - View materialization
 - Distributed materializations
 - Models with Replicated engines
 
-table and incremental materializations with non-replicated engine will not be affected by `cluster` setting (model would be created on the connected node only).
+table and incremental materializations with non-replicated engine will not be affected by `cluster` setting (model would
+be created on the connected node only).
 
 ### Compatibility
 
-
-If a model has been created without a `cluster` setting, dbt-clickhouse will detect the situation and run all DDL/DML without `on cluster` clause for this model.
-
+If a model has been created without a `cluster` setting, dbt-clickhouse will detect the situation and run all DDL/DML
+without `on cluster` clause for this model.
 
 ## A Note on Model Settings
 
-ClickHouse has several types/levels of "settings".  In the model configuration above, two types of these are configurable.  `settings` means the `SETTINGS`
-clause used in `CREATE TABLE/VIEW` types of DDL statements, so this is generally settings that are specific to the specific ClickHouse table engine.  The new
-`query_settings` is use to add a `SETTINGS` clause to the `INSERT` and `DELETE` queries used for model materialization (including incremental materializations).
-There are hundreds of ClickHouse settings, and it's not always clear which is a "table" setting and which is a "user" setting (although the latter are generally
-available in the `system.settings` table.)  In general the defaults are recommended, and any use of these properties should be carefully researched and tested.
-
+ClickHouse has several types/levels of "settings". In the model configuration above, two types of these are
+configurable.  `settings` means the `SETTINGS`
+clause used in `CREATE TABLE/VIEW` types of DDL statements, so this is generally settings that are specific to the
+specific ClickHouse table engine. The new
+`query_settings` is use to add a `SETTINGS` clause to the `INSERT` and `DELETE` queries used for model materialization (
+including incremental materializations).
+There are hundreds of ClickHouse settings, and it's not always clear which is a "table" setting and which is a "user"
+setting (although the latter are generally
+available in the `system.settings` table.)  In general the defaults are recommended, and any use of these properties
+should be carefully researched and tested.
 
 ## Known Limitations
 
-* Ephemeral models/CTEs don't work if placed before the "INSERT INTO" in a ClickHouse insert statement, see https://github.com/ClickHouse/ClickHouse/issues/30323.  This
-should not affect most models, but care should be taken where an ephemeral model is placed in model definitions and other SQL statements.
+* Ephemeral models/CTEs don't work if placed before the "INSERT INTO" in a ClickHouse insert statement,
+  see https://github.com/ClickHouse/ClickHouse/issues/30323. This
+  should not affect most models, but care should be taken where an ephemeral model is placed in model definitions and
+  other SQL statements.
 
 ## Incremental Model Strategies
 
 As of version 1.3.2, dbt-clickhouse supports three incremental model strategies.
 
-### The Default (Legacy) Strategy  
+### The Default (Legacy) Strategy
 
-Historically ClickHouse has had only limited support for updates and deletes, in the form of asynchronous "mutations."  To emulate expected dbt behavior,
-dbt-clickhouse by default creates a new temporary table containing all unaffected (not deleted, not changed) "old" records, plus any new or updated records,
-and then swaps or exchanges this temporary table with the existing incremental model relation.  This is the only strategy that preserves the original relation if something
-goes wrong before the operation completes; however, since it involves a full copy of the original table, it can be quite expensive and slow to execute.
+Historically ClickHouse has had only limited support for updates and deletes, in the form of asynchronous "mutations."
+To emulate expected dbt behavior,
+dbt-clickhouse by default creates a new temporary table containing all unaffected (not deleted, not changed) "old"
+records, plus any new or updated records,
+and then swaps or exchanges this temporary table with the existing incremental model relation. This is the only strategy
+that preserves the original relation if something
+goes wrong before the operation completes; however, since it involves a full copy of the original table, it can be quite
+expensive and slow to execute.
 
 ### The Delete+Insert Strategy
 
-ClickHouse added "lightweight deletes" as an experimental feature in version 22.8.  Lightweight deletes are significantly faster than ALTER TABLE ... DELETE
-operations, because they don't require rewriting ClickHouse data parts.  The incremental strategy `delete+insert` utilizes lightweight deletes to implement
-incremental materializations that perform significantly better than the "legacy" strategy.  However, there are important caveats to using this strategy:
-- Lightweight deletes must be enabled on your ClickHouse server using the setting `allow_experimental_lightweight_delete=1` or you 
-must set `use_lw_deletes=true` in your profile (which will enable that setting for your dbt sessions)
-- Lightweight deletes are now production ready, but there may be performance and other problems on ClickHouse versions earlier than 23.3.
-- This strategy operates directly on the affected table/relation (with creating any intermediate or temporary tables), so if there is an issue during the operation, the
-data in the incremental model is likely to be in an invalid state
-- When using lightweight deletes, dbt-clickhouse enabled the setting `allow_nondeterministic_mutations`.  In some very rare cases using non-deterministic incremental_predicates
-this could result in a race condition for the updated/deleted items (and related log messages in the ClickHouse logs).  To ensure consistent results the
-incremental predicates should only include sub-queries on data that will not be modified during the incremental materialization.
+ClickHouse added "lightweight deletes" as an experimental feature in version 22.8. Lightweight deletes are significantly
+faster than ALTER TABLE ... DELETE
+operations, because they don't require rewriting ClickHouse data parts. The incremental strategy `delete+insert`
+utilizes lightweight deletes to implement
+incremental materializations that perform significantly better than the "legacy" strategy. However, there are important
+caveats to using this strategy:
+
+- Lightweight deletes must be enabled on your ClickHouse server using the setting
+  `allow_experimental_lightweight_delete=1` or you
+  must set `use_lw_deletes=true` in your profile (which will enable that setting for your dbt sessions)
+- Lightweight deletes are now production ready, but there may be performance and other problems on ClickHouse versions
+  earlier than 23.3.
+- This strategy operates directly on the affected table/relation (with creating any intermediate or temporary tables),
+  so if there is an issue during the operation, the
+  data in the incremental model is likely to be in an invalid state
+- When using lightweight deletes, dbt-clickhouse enabled the setting `allow_nondeterministic_mutations`. In some very
+  rare cases using non-deterministic incremental_predicates
+  this could result in a race condition for the updated/deleted items (and related log messages in the ClickHouse logs).
+  To ensure consistent results the
+  incremental predicates should only include sub-queries on data that will not be modified during the incremental
+  materialization.
 
 ### The Append Strategy
 
-This strategy replaces the `inserts_only` setting in previous versions of dbt-clickhouse.  This approach simply appends new rows to the existing relation.
-As a result duplicate rows are not eliminated, and there is no temporary or intermediate table.  It is the fastest approach if duplicates are either permitted
+This strategy replaces the `inserts_only` setting in previous versions of dbt-clickhouse. This approach simply appends
+new rows to the existing relation.
+As a result duplicate rows are not eliminated, and there is no temporary or intermediate table. It is the fastest
+approach if duplicates are either permitted
 in the data or excluded by the incremental query WHERE clause/filter.
 
 ### The insert_overwrite Strategy (Experimental)
+
 > [IMPORTANT]  
-> Currently, the insert_overwrite strategy is not fully functional with distributed materializations. 
- 
+> Currently, the insert_overwrite strategy is not fully functional with distributed materializations.
+
 Performs the following steps:
-1. Create a staging (temporary) table with the same structure as the incremental model relation: `CREATE TABLE <staging> AS <target>`.
+
+1. Create a staging (temporary) table with the same structure as the incremental model relation:
+   `CREATE TABLE <staging> AS <target>`.
 2. Insert only new records (produced by `SELECT`) into the staging table.
 3. Replace only new partitions (present in the staging table) into the target table.
 
 This approach has the following advantages:
-- It is faster than the default strategy because it doesn't copy the entire table.
-- It is safer than other strategies because it doesn't modify the original table until the INSERT operation completes successfully: in case of intermediate failure, the original table is not modified.
-- It implements "partitions immutability" data engineering best practice. Which simplifies incremental and parallel data processing, rollbacks, etc.
 
-The strategy requires `partition_by` to be set in the model configuration. Ignores all other strategies-specific parameters of the model config.
+- It is faster than the default strategy because it doesn't copy the entire table.
+- It is safer than other strategies because it doesn't modify the original table until the INSERT operation completes
+  successfully: in case of intermediate failure, the original table is not modified.
+- It implements "partitions immutability" data engineering best practice. Which simplifies incremental and parallel data
+  processing, rollbacks, etc.
+
+The strategy requires `partition_by` to be set in the model configuration. Ignores all other strategies-specific
+parameters of the model config.
 
 ## Additional ClickHouse Macros
 
 ### Model Materialization Utility Macros
 
 The following macros are included to facilitate creating ClickHouse specific tables and views:
-- `engine_clause` -- Uses the `engine` model configuration property to assign a ClickHouse table engine.  dbt-clickhouse uses the `MergeTree` engine by default.
-- `partition_cols` -- Uses the `partition_by` model configuration property to assign a ClickHouse partition key.  No partition key is assigned by default.
-- `order_cols` -- Uses the `order_by` model configuration to assign a ClickHouse order by/sorting key.  If not specified ClickHouse will use an empty tuple() and the table will be unsorted
-- `primary_key_clause` -- Uses the `primary_key` model configuration property to assign a ClickHouse primary key.  By default, primary key is set and ClickHouse will use the order by clause as the primary key. 
-- `on_cluster_clause` -- Uses the `cluster` profile property to add an `ON CLUSTER` clause to certain dbt-operations: distributed materializations, views creation, database creation.
-- `ttl_config` -- Uses the `ttl` model configuration property to assign a ClickHouse table TTL expression.  No TTL is assigned by default.
+
+- `engine_clause` -- Uses the `engine` model configuration property to assign a ClickHouse table engine. dbt-clickhouse
+  uses the `MergeTree` engine by default.
+- `partition_cols` -- Uses the `partition_by` model configuration property to assign a ClickHouse partition key. No
+  partition key is assigned by default.
+- `order_cols` -- Uses the `order_by` model configuration to assign a ClickHouse order by/sorting key. If not specified
+  ClickHouse will use an empty tuple() and the table will be unsorted
+- `primary_key_clause` -- Uses the `primary_key` model configuration property to assign a ClickHouse primary key. By
+  default, primary key is set and ClickHouse will use the order by clause as the primary key.
+- `on_cluster_clause` -- Uses the `cluster` profile property to add an `ON CLUSTER` clause to certain dbt-operations:
+  distributed materializations, views creation, database creation.
+- `ttl_config` -- Uses the `ttl` model configuration property to assign a ClickHouse table TTL expression. No TTL is
+  assigned by default.
 
 ### s3Source Helper Macro
 
-The `s3source` macro simplifies the process of selecting ClickHouse data directly from S3 using the ClickHouse S3 table function.  It works by
-populating the S3 table function parameters from a named configuration dictionary (the name of the dictionary must end in `s3`).  The macro
-first looks for the dictionary in the profile `vars`, and then in the model configuration.  The dictionary can contain any of the following
+The `s3source` macro simplifies the process of selecting ClickHouse data directly from S3 using the ClickHouse S3 table
+function. It works by
+populating the S3 table function parameters from a named configuration dictionary (the name of the dictionary must end
+in `s3`). The macro
+first looks for the dictionary in the profile `vars`, and then in the model configuration. The dictionary can contain
+any of the following
 keys used to populate the parameters of the S3 table function:
 
 | Argument Name         | Description                                                                                                                                                                                  |
@@ -230,25 +274,38 @@ keys used to populate the parameters of the S3 table function:
 | aws_secret_access_key | The S3 secret key.                                                                                                                                                                           |
 | role_arn              | The ARN of a ClickhouseAccess IAM role to use to securely access the S3 objects. See this [documentation](https://clickhouse.com/docs/en/cloud/security/secure-s3) for more information.     |
 | compression           | The compression method used with the S3 objects.  If not provided ClickHouse will attempt to determine compression based on the file name.                                                   |
-See the [S3 test file](https://github.com/ClickHouse/dbt-clickhouse/blob/main/tests/integration/adapter/clickhouse/test_clickhouse_s3.py) for examples of how to use this macro.
+
+See
+the [S3 test file](https://github.com/ClickHouse/dbt-clickhouse/blob/main/tests/integration/adapter/clickhouse/test_clickhouse_s3.py)
+for examples of how to use this macro.
 
 # Contracts and Constraints
 
-Only exact column type contracts are supported.  For example, a contract with a UInt32 column type will fail if the model returns a UInt64 or other integer type.
-ClickHouse also support _only_ `CHECK` constraints on the entire table/model.  Primary key, foreign key, unique, and column level CHECK constraints are not supported.
+Only exact column type contracts are supported. For example, a contract with a UInt32 column type will fail if the model
+returns a UInt64 or other integer type.
+ClickHouse also support _only_ `CHECK` constraints on the entire table/model. Primary key, foreign key, unique, and
+column level CHECK constraints are not supported.
 (See ClickHouse documentation on primary/order by keys.)
 
 # Materialized Views (Experimental)
-A `materialized_view` materialization should be a `SELECT` from an existing (source) table.  The adapter will create a target table with the model name
-and a ClickHouse MATERIALIZED VIEW with the name `<model_name>_mv`.  Unlike PostgreSQL, a ClickHouse materialized view is not "static" (and has
-no corresponding REFRESH operation).  Instead, it acts as an "insert trigger", and will insert new rows into the target table using the defined `SELECT`
-"transformation" in the view definition on rows inserted into the source table.  See the [test file]
-(https://github.com/ClickHouse/dbt-clickhouse/blob/main/tests/integration/adapter/materialized_view/test_materialized_view.py)  for an introductory example
+
+A `materialized_view` materialization should be a `SELECT` from an existing (source) table. The adapter will create a
+target table with the model name
+and a ClickHouse MATERIALIZED VIEW with the name `<model_name>_mv`. Unlike PostgreSQL, a ClickHouse materialized view is
+not "static" (and has
+no corresponding REFRESH operation). Instead, it acts as an "insert trigger", and will insert new rows into the target
+table using the defined `SELECT`
+"transformation" in the view definition on rows inserted into the source table. See the [test file]
+(https://github.com/ClickHouse/dbt-clickhouse/blob/main/tests/integration/adapter/materialized_view/test_materialized_view.py)
+for an introductory example
 of how to use this functionality.
 
-Clickhouse provides the ability for more than one materialized view to write records to the same target table. To support this in dbt-clickhouse, you can construct a `UNION` in your model file, such that the SQL for each of your materialized views is wrapped with comments of the form `--my_mv_name:begin` and `--my_mv_name:end`.
+Clickhouse provides the ability for more than one materialized view to write records to the same target table. To
+support this in dbt-clickhouse, you can construct a `UNION` in your model file, such that the SQL for each of your
+materialized views is wrapped with comments of the form `--my_mv_name:begin` and `--my_mv_name:end`.
 
-For example the following will build two materialized views both writing data to the same destination table of the model. The names of the materialized views will take the form `<model_name>_mv1` and `<model_name>_mv2` :
+For example the following will build two materialized views both writing data to the same destination table of the
+model. The names of the materialized views will take the form `<model_name>_mv1` and `<model_name>_mv2` :
 
 ```
 --mv1:begin
@@ -260,17 +317,23 @@ select a,b,c from {{ source('raw', 'table_2') }}
 --mv2:end
 ```
 
-> IMPORTANT!  
-> 
-> When updating a model with multiple materialized views (MVs), especially when renaming one of the MV names, dbt-clickhouse does not automatically drop the old MV. Instead,
-> you will encounter the following warning: `Warning - Table <previous table name> was detected with the same pattern as model name <your model name> but was not found in this run. In case it is a renamed mv that was previously part of this model, drop it manually (!!!) `
+> IMPORTANT!
+>
+> When updating a model with multiple materialized views (MVs), especially when renaming one of the MV names,
+> dbt-clickhouse does not automatically drop the old MV. Instead,
+> you will encounter the following warning:
+`Warning - Table <previous table name> was detected with the same pattern as model name <your model name> but was not found in this run. In case it is a renamed mv that was previously part of this model, drop it manually (!!!) `
 
 ## Data catchup
-Currently, when creating a materialized view (MV), the target table is first populated with historical data before the MV itself is created.
 
-In other words, dbt-clickhouse initially creates the target table and preloads it with historical data based on the query defined for the MV. Only after this step is the MV created.
+Currently, when creating a materialized view (MV), the target table is first populated with historical data before the
+MV itself is created.
 
-If you prefer not to preload historical data during MV creation, you can disable this behavior by setting the catchup config to False:
+In other words, dbt-clickhouse initially creates the target table and preloads it with historical data based on the
+query defined for the MV. Only after this step is the MV created.
+
+If you prefer not to preload historical data during MV creation, you can disable this behavior by setting the catchup
+config to False:
 
 ```python
 {{config(
@@ -281,27 +344,66 @@ If you prefer not to preload historical data during MV creation, you can disable
 )}}
 ```
 
+## Refreshable Materialized Views
+
+To use [Refreshable Materialized View](https://clickhouse.com/docs/en/materialized-view/refreshable-materialized-view),
+please adjust the following configs as needed in your MV model (all these configs are supposed to be set inside a
+refreshable config object):
+
+| Option                | Description                                                                                                                                                              | Required | Default Value |
+|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|---------------|
+| refresh_interval      | The interval clause (required)                                                                                                                                           | Yes      |               |
+| randomize             | The randomization clause, will appear after `RANDOMIZE FOR`                                                                                                              |          |               |
+| append                | If set to `True`, each refresh inserts rows into the table without deleting existing rows. The insert is not atomic, just like a regular INSERT SELECT.                  |          | False         |
+| depends_on            | A dependencies list for the refreshable mv. Please provide the dependencies in the following format `{schema}.{view_name}`                                               |          |               |
+| depends_on_validation | Whether to validate the existence of the dependencies provided in `depends_on`. In case a dependency doesn't contain a schema, the validation occurs on schema `default` |          | False         |
+
+A config example for refreshable materialized view:
+```python
+{{
+    config(
+        materialized='materialized_view',
+        refreshable={
+                "interval": "EVERY 5 MINUTE",
+                "randomize": "1 MINUTE",
+                "append": True,
+                "depends_on": ['schema.depend_on_model'],
+                "depends_on_validation": True
+        }
+        )
+}}
+```
+
+> [!IMPORTANT]
+> The refreshable feature was not tested with multiple mvs directing to the same target model.
 
 # Dictionary materializations (experimental)
-See the tests in https://github.com/ClickHouse/dbt-clickhouse/blob/main/tests/integration/adapter/dictionary/test_dictionary.py for examples of how to
-implement materializations for ClickHouse dictionaries 
+
+See the tests
+in https://github.com/ClickHouse/dbt-clickhouse/blob/main/tests/integration/adapter/dictionary/test_dictionary.py for
+examples of how to
+implement materializations for ClickHouse dictionaries
 
 # Distributed materializations
 
 Notes:
 
-- dbt-clickhouse queries now automatically include the setting `insert_distributed_sync = 1` in order to ensure that downstream incremental
-materialization operations execute correctly.  This could cause some distributed table inserts to run more slowly than expected.
+- dbt-clickhouse queries now automatically include the setting `insert_distributed_sync = 1` in order to ensure that
+  downstream incremental
+  materialization operations execute correctly. This could cause some distributed table inserts to run more slowly than
+  expected.
 
 ## Distributed table materialization
 
 Distributed table created with following steps:
+
 1. Creates temp view with sql query to get right structure
-2. Create empty local tables based on view 
-3. Create distributed table based on local tables. 
+2. Create empty local tables based on view
+3. Create distributed table based on local tables.
 4. Data inserts into distributed table, so it is distributed across shards without duplicating.
 
 ### Distributed table model example
+
 ```sql
 {{
     config(
@@ -312,7 +414,8 @@ Distributed table created with following steps:
     )
 }}
 
-select id, created_at, item from {{ source('db', 'table') }}
+select id, created_at, item
+from {{ source('db', 'table') }}
 ```
 
 ### Generated migrations
@@ -320,36 +423,56 @@ select id, created_at, item from {{ source('db', 'table') }}
 ```sql
 CREATE TABLE db.table_local on cluster cluster
 (
-    `id` UInt64,
-    `created_at` DateTime,
-    `item` String
+    `id`
+    UInt64,
+    `created_at`
+    DateTime,
+    `item`
+    String
 )
-ENGINE = ReplacingMergeTree
-ORDER BY (id, created_at)
-SETTINGS index_granularity = 8192;
+    ENGINE = ReplacingMergeTree
+    ORDER BY
+(
+    id,
+    created_at
+)
+    SETTINGS index_granularity = 8192;
 
 
 CREATE TABLE db.table on cluster cluster
 (
-    `id` UInt64,
-    `created_at` DateTime,
-    `item` String
+    `id`
+    UInt64,
+    `created_at`
+    DateTime,
+    `item`
+    String
 )
-ENGINE = Distributed('cluster', 'db', 'table_local', cityHash64(id));
+    ENGINE = Distributed
+(
+    'cluster',
+    'db',
+    'table_local',
+    cityHash64
+(
+    id
+));
 ```
 
 ## Distributed incremental materialization
 
-Incremental model based on the same idea as distributed table, the main difficulty is to process all incremental strategies correctly.
+Incremental model based on the same idea as distributed table, the main difficulty is to process all incremental
+strategies correctly.
 
 1. _The Append Strategy_ just insert data into distributed table.
 2. _The Delete+Insert_ Strategy creates distributed temp table to work with all data on every shard.
 3. _The Default (Legacy) Strategy_ creates distributed temp and intermediate tables for the same reason.
 
-Only shard tables are replacing, because distributed table does not keep data. 
+Only shard tables are replacing, because distributed table does not keep data.
 The distributed table reloads only when the full_refresh mode is enabled or the table structure may have changed.
 
 ### Distributed incremental model example
+
 ```sql
 {{
     config(
@@ -360,7 +483,8 @@ The distributed table reloads only when the full_refresh mode is enabled or the 
     )
 }}
 
-select id, created_at, item from {{ source('db', 'table') }}
+select id, created_at, item
+from {{ source('db', 'table') }}
 ```
 
 ### Generated migrations
@@ -368,27 +492,46 @@ select id, created_at, item from {{ source('db', 'table') }}
 ```sql
 CREATE TABLE db.table_local on cluster cluster
 (
-    `id` UInt64,
-    `created_at` DateTime,
-    `item` String
+    `id`
+    UInt64,
+    `created_at`
+    DateTime,
+    `item`
+    String
 )
-ENGINE = MergeTree
-SETTINGS index_granularity = 8192;
+    ENGINE = MergeTree
+    SETTINGS index_granularity = 8192;
 
 
 CREATE TABLE db.table on cluster cluster
 (
-    `id` UInt64,
-    `created_at` DateTime,
-    `item` String
+    `id`
+    UInt64,
+    `created_at`
+    DateTime,
+    `item`
+    String
 )
-ENGINE = Distributed('cluster', 'db', 'table_local', cityHash64(id));
+    ENGINE = Distributed
+(
+    'cluster',
+    'db',
+    'table_local',
+    cityHash64
+(
+    id
+));
 ```
 
 ## Contributing
-We welcome contributions from the community to help improve the dbt-ClickHouse adapter. Whether you’re fixing a bug, adding a new feature, or enhancing documentation, your efforts are greatly appreciated!
 
-Please take a moment to read our [Contribution Guide](CONTRIBUTING.md) to get started. The guide provides detailed instructions on setting up your environment, running tests, and submitting pull requests.
+We welcome contributions from the community to help improve the dbt-ClickHouse adapter. Whether you’re fixing a bug,
+adding a new feature, or enhancing documentation, your efforts are greatly appreciated!
+
+Please take a moment to read our [Contribution Guide](CONTRIBUTING.md) to get started. The guide provides detailed
+instructions on setting up your environment, running tests, and submitting pull requests.
 
 ## Original Author
-ClickHouse wants to thank @[silentsokolov](https://github.com/silentsokolov) for creating this connector and for their valuable contributions.
+
+ClickHouse wants to thank @[silentsokolov](https://github.com/silentsokolov) for creating this connector and for their
+valuable contributions.

--- a/dbt/include/clickhouse/macros/materializations/materialized_view.sql
+++ b/dbt/include/clickhouse/macros/materializations/materialized_view.sql
@@ -289,7 +289,8 @@
   {% endset %}
 
   {% set tables_result = run_query(query) %}
-  {% if tables_result is not none and tables_result.columns %}
+    {{ log(tables_result.columns[0].values()[0]) }}
+  {% if tables_result.columns[0].values()[0] > 0 %}
     {{ log('MV ' + mv + ' exists.') }}
   {% else %}
     {% do exceptions.raise_compiler_error(

--- a/dbt/include/clickhouse/macros/materializations/materialized_view.sql
+++ b/dbt/include/clickhouse/macros/materializations/materialized_view.sql
@@ -222,6 +222,7 @@
 
     {% if refresh_interval %}
       REFRESH {{ refresh_interval }}
+      {# This is a comment to force a new line between REFRESH and RANDOMIZE clauses #}
       {%- if refresh_randomize -%}
         RANDOMIZE FOR {{ refresh_randomize }}
       {%- endif -%}

--- a/dbt/include/clickhouse/macros/materializations/materialized_view.sql
+++ b/dbt/include/clickhouse/macros/materializations/materialized_view.sql
@@ -283,7 +283,7 @@
   {%- set condition = "database='" + database + "' and view='" + table + "'" %}
 
   {% set query %}
-    select database, view
+    select count(*)
     from system.view_refreshes
     where {{ condition }}
   {% endset %}

--- a/dbt/include/clickhouse/macros/materializations/materialized_view.sql
+++ b/dbt/include/clickhouse/macros/materializations/materialized_view.sql
@@ -210,7 +210,7 @@
     {% set refresh_interval = refreshable_config.get('interval', none) %}
     {% set refresh_randomize = refreshable_config.get('randomize', none) %}
     {% set depends_on = refreshable_config.get('depends_on', none) %}
-    {% set depends_on_validation = refreshable_config.get('depends_on_validation', true) %}
+    {% set depends_on_validation = refreshable_config.get('depends_on_validation', false) %}
     {% set append = refreshable_config.get('append', false) %}
 
     {% if not refresh_interval %}

--- a/tests/integration/adapter/materialized_view/test_refreshable_materialized_view.py
+++ b/tests/integration/adapter/materialized_view/test_refreshable_materialized_view.py
@@ -1,0 +1,122 @@
+"""
+test refreshable materialized view creation. This is ClickHouse specific, which has a significantly different implementation
+of materialized views from PostgreSQL or Oracle
+"""
+
+import json
+
+import pytest
+from dbt.tests.util import check_relation_types, run_dbt
+
+PEOPLE_SEED_CSV = """
+id,name,age,department
+1231,Dade,33,engineering
+6666,Ksenia,48,engineering
+8888,Kate,50,engineering
+1000,Alfie,10,sales
+2000,Bill,20,sales
+3000,Charlie,30,sales
+""".lstrip()
+
+# This model is parameterized, in a way, by the "run_type" dbt project variable
+# This is to be able to switch between different model definitions within
+# the same test run and allow us to test the evolution of a materialized view
+MV_MODEL = """
+{{ config(
+       materialized='materialized_view',
+       engine='MergeTree()',
+       order_by='(department)',
+       refreshable=(
+           {
+               "interval": "EVERY 2 MINUTE",
+               "depends_on": ['depend_on_model'],
+               "depends_on_validation": True
+           } if var('run_type', '') == 'validate_depends_on' else {
+               "interval": "EVERY 2 MINUTE"
+           }
+       )
+       )
+ }}
+select
+    department,
+    avg(age) as average
+    from {{ source('raw', 'people') }}
+group by department
+"""
+
+SEED_SCHEMA_YML = """
+version: 2
+
+sources:
+  - name: raw
+    schema: "{{ target.schema }}"
+    tables:
+      - name: people
+"""
+
+
+class TestBasicRefreshableMV:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        """
+        we need a base table to pull from
+        """
+        return {
+            "people.csv": PEOPLE_SEED_CSV,
+            "schema.yml": SEED_SCHEMA_YML,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "hackers.sql": MV_MODEL,
+        }
+
+    def test_create(self, project):
+        """
+        1. create a base table via dbt seed
+        2. create a model as a refreshable materialized view, selecting from the table created in (1)
+        3. check in system.view_refreshes for the table existence
+        """
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+        columns = project.run_sql(f"DESCRIBE TABLE {project.test_schema}.people", fetch="all")
+        assert columns[0][1] == "Int32"
+
+        # create the model
+        results = run_dbt()
+        assert len(results) == 1
+
+        columns = project.run_sql(f"DESCRIBE TABLE hackers", fetch="all")
+        assert columns[0][1] == "String"
+
+        columns = project.run_sql(f"DESCRIBE hackers_mv", fetch="all")
+        assert columns[0][1] == "String"
+
+        check_relation_types(
+            project.adapter,
+            {
+                "hackers_mv": "view",
+                "hackers": "table",
+            },
+        )
+
+        result = project.run_sql(f"select database, view, status from system.view_refreshes where database= '{project.test_schema}' and view='hackers_mv'", fetch="all")
+        assert result[0][2] == 'Scheduled'
+
+    def test_validate_dependency(self, project):
+        """
+        1. create a base table via dbt seed
+        2. create a refreshable mv model with non exist dependency and validation config, selecting from the table created in (1)
+        3. make sure we get an error
+        """
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+        columns = project.run_sql(f"DESCRIBE TABLE {project.test_schema}.people", fetch="all")
+        assert columns[0][1] == "Int32"
+
+        # re-run dbt but this time with the new MV SQL
+        run_vars = {"run_type": "validate_depends_on"}
+        result = run_dbt(["run", "--vars", json.dumps(run_vars)], False)
+        assert result[0].status == 'error'
+        assert 'No existing MV found matching MV' in result[0].message

--- a/tests/integration/adapter/materialized_view/test_refreshable_materialized_view.py
+++ b/tests/integration/adapter/materialized_view/test_refreshable_materialized_view.py
@@ -101,7 +101,10 @@ class TestBasicRefreshableMV:
             },
         )
 
-        result = project.run_sql(f"select database, view, status from system.view_refreshes where database= '{project.test_schema}' and view='hackers_mv'", fetch="all")
+        result = project.run_sql(
+            f"select database, view, status from system.view_refreshes where database= '{project.test_schema}' and view='hackers_mv'",
+            fetch="all"
+        )
         assert result[0][2] == 'Scheduled'
 
     def test_validate_dependency(self, project):

--- a/tests/integration/adapter/materialized_view/test_refreshable_materialized_view.py
+++ b/tests/integration/adapter/materialized_view/test_refreshable_materialized_view.py
@@ -103,7 +103,7 @@ class TestBasicRefreshableMV:
 
         result = project.run_sql(
             f"select database, view, status from system.view_refreshes where database= '{project.test_schema}' and view='hackers_mv'",
-            fetch="all"
+            fetch="all",
         )
         assert result[0][2] == 'Scheduled'
 


### PR DESCRIPTION
## Summary
Closes #252

This PR enhances the current mv implementation by introducing the ability to create refreshable materialized views.
Important Note: Currently, there is no direct "dbt linkage" between materialized views and their dependencies. As a result, the order of creation for dependencies is not guaranteed.

A potential solution to address this limitation is to pass a dbt ref object to the dependency list. However, this would require implementing MessagePack serialization to handle the references appropriately.
