### PR TITLE
fix: remove python 3.8 from various places, #385

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         'clickhouse-driver>=0.2.6',
         'setuptools>=0.69',
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     platforms='any',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -67,7 +67,6 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: POSIX :: Linux',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
## Summary
This pull request includes a change to the `setup.py` file to update the required Python version for the project.

Dependencies and requirements update:

* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L62-L70): Updated `python_requires` to require Python version 3.9 or higher and removed the classifier for Python 3.8.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
