### PR TITLE
fix: replicated database materializations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ The index config should be added to the model config. for instance:
          }]
   ) }}
   ```
- 
+
+### Bug Fixes
+* Materializations are now compatible with `Replicated` database engine, as they will no longer use `ON CLUSTER` statements.
+
 ### Release [1.8.7], 2025-01-05
 
 ### New Features

--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -176,7 +176,7 @@ class ClickHouseAdapter(SQLAdapter):
     def should_on_cluster(self, materialized: str = '', engine: str = '') -> bool:
         conn = self.connections.get_if_exists()
         if conn and conn.credentials.cluster:
-            return ClickHouseRelation.get_on_cluster(conn.credentials.cluster, materialized, engine)
+            return ClickHouseRelation.get_on_cluster(conn.credentials.cluster, materialized, engine, conn.credentials.database_engine)
         return ClickHouseRelation.get_on_cluster('', materialized, engine)
 
     @available.parse_none
@@ -324,6 +324,7 @@ class ClickHouseAdapter(SQLAdapter):
                 and rel_type == ClickHouseRelationType.Table
                 and db_engine in ('Atomic', 'Replicated')
             )
+            can_on_cluster = (on_cluster >= 1) and db_engine != 'Replicated'
 
             relation = self.Relation.create(
                 database='',
@@ -331,7 +332,7 @@ class ClickHouseAdapter(SQLAdapter):
                 identifier=name,
                 type=rel_type,
                 can_exchange=can_exchange,
-                can_on_cluster=(on_cluster >= 1),
+                can_on_cluster=can_on_cluster,
             )
             relations.append(relation)
 

--- a/dbt/adapters/clickhouse/relation.py
+++ b/dbt/adapters/clickhouse/relation.py
@@ -78,17 +78,17 @@ class ClickHouseRelation(BaseRelation):
 
     @classmethod
     def get_on_cluster(
-        cls: Type[Self], cluster: str = '', materialized: str = '', engine: str = ''
+        cls: Type[Self], cluster: str = '', materialized: str = '', engine: str = '', database_engine: str = ''
     ) -> bool:
+        if 'replicated' in database_engine.lower():
+            return False
         if cluster.strip():
             return (
                 materialized in ('view', 'dictionary')
                 or 'distributed' in materialized
                 or 'Replicated' in engine
             )
-
-        else:
-            return False
+        return False
 
     @classmethod
     def create_from(
@@ -126,7 +126,8 @@ class ClickHouseRelation(BaseRelation):
         else:
             materialized = relation_config.config.get('materialized') or ''
             engine = relation_config.config.get('engine') or ''
-            can_on_cluster = cls.get_on_cluster(cluster, materialized, engine)
+            database_engine = quoting.credentials.database_engine or ''
+            can_on_cluster = cls.get_on_cluster(cluster, materialized, engine, database_engine)
 
         return cls.create(
             database='',

--- a/dbt/include/clickhouse/macros/adapters.sql
+++ b/dbt/include/clickhouse/macros/adapters.sql
@@ -59,14 +59,13 @@
 
 {% macro clickhouse__drop_relation(relation, obj_type='table') -%}
   {% call statement('drop_relation', auto_begin=False) -%}
-    {# drop relation on cluster by default if cluster is set #}
-    drop {{ obj_type }} if exists {{ relation }} {{ on_cluster_clause(relation.without_identifier(), True)}}
+    drop {{ obj_type }} if exists {{ relation }} {{ on_cluster_clause(relation, True)}}
   {%- endcall %}
 {% endmacro %}
 
 {% macro clickhouse__rename_relation(from_relation, to_relation, obj_type='table') -%}
   {% call statement('drop_relation') %}
-    drop {{ obj_type }} if exists {{ to_relation }} {{ on_cluster_clause(to_relation.without_identifier())}}
+    drop {{ obj_type }} if exists {{ to_relation }} {{ on_cluster_clause(to_relation)}}
   {% endcall %}
   {% call statement('rename_relation') %}
     rename {{ obj_type }} {{ from_relation }} to {{ to_relation }} {{ on_cluster_clause(from_relation)}}

--- a/tests/integration/adapter/replicated_database/test_replicated_database.py
+++ b/tests/integration/adapter/replicated_database/test_replicated_database.py
@@ -1,0 +1,31 @@
+import pytest
+
+from dbt.tests.adapter.basic.test_incremental import BaseIncremental
+from dbt.tests.adapter.basic.test_base import BaseSimpleMaterializations
+from dbt.tests.adapter.basic.files import model_incremental, schema_base_yml
+
+
+class TestReplicatedDatabaseSimpleMaterialization(BaseSimpleMaterializations):
+    """Contains tests for table, view and swappable view materialization."""
+    @pytest.fixture(scope="class")
+    def test_config(self, test_config):
+        test_config["db_engine"] = "Replicated('/clickhouse/databases/{uuid}', '{shard}', '{replica}')"
+        return test_config
+
+
+class TestReplicatedDatabaseIncremental(BaseIncremental):
+    @pytest.fixture(scope="class")
+    def test_config(self, test_config):
+        test_config["db_engine"] = "Replicated('/clickhouse/databases/{uuid}', '{shard}', '{replica}')"
+        return test_config
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        config_materialized_incremental = """
+          {{ config(order_by='(some_date, id, name)', inserts_only=True, materialized='incremental', unique_key='id') }}
+        """
+        incremental_sql = config_materialized_incremental + model_incremental
+        return {
+            "incremental.sql": incremental_sql,
+            "schema.yml": schema_base_yml,
+        }


### PR DESCRIPTION
## Summary
Previously, table and view materializations wouldn't work with a `Replicated` database configured, as they would run `ON CLUSTER` statements for some of the ddl's. This is not allowed in replicated databases and would lead to the following error:
```
DB::Exception: It's not initial query. ON CLUSTER is not allowed for Replicated database. (INCORRECT_QUERY) (version 24.11.1.2557 (official build)
```
This mr fixes these issues by adding conditions for on cluster statements with replicated databases. 

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
