### PR TITLE
feat: allow using TLS client certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Release [x.x.x]
+
+#### Improvements
+* It is now possible to configure a TLS client certificate using `client_cert` and `client_cert_key` profile parameters. ([#413](https://github.com/ClickHouse/dbt-clickhouse/pull/413))
+
 ### Release [1.8.8], 2025-02-05
 ### Improvements
 * Materialized view now attempts to use `ALTER TABLE...MODIFY QUERY` to update existing materialized views. This is an atomic operation so data is not lost. ([#390](https://github.com/ClickHouse/dbt-clickhouse/pull/390))

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ your_profile_name:
       cluster: [<empty string>] # If set, certain DDL/table operations will be executed with the `ON CLUSTER` clause using this cluster. Distributed materializations require this setting to work. See the following ClickHouse Cluster section for more details.
       verify: [True] # Validate TLS certificate if using TLS/SSL
       secure: [False] # Use TLS (native protocol) or HTTPS (http protocol)
+      client_cert: [null] # Path to a TLS client certificate in .pem format
+      client_cert_key: [null] # Path to the private key for the TLS client certificate
       retries: [1] # Number of times to retry a "retriable" database exception (such as a 503 'Service Unavailable' error)
       compression: [<empty string>] # Use gzip compression if truthy (http), or compression type for a native connection
       connect_timeout: [10] # Timeout in seconds to establish a connection to ClickHouse

--- a/dbt/adapters/clickhouse/credentials.py
+++ b/dbt/adapters/clickhouse/credentials.py
@@ -24,6 +24,8 @@ class ClickHouseCredentials(Credentials):
     cluster_mode: bool = False
     secure: bool = False
     verify: bool = True
+    client_cert: Optional[str] = None
+    client_cert_key: Optional[str] = None
     connect_timeout: int = 10
     send_receive_timeout: int = 300
     sync_request_timeout: int = 5
@@ -72,6 +74,8 @@ class ClickHouseCredentials(Credentials):
             'cluster_mode',
             'secure',
             'verify',
+            'client_cert',
+            'client_cert_key',
             'connect_timeout',
             'send_receive_timeout',
             'sync_request_timeout',

--- a/dbt/adapters/clickhouse/httpclient.py
+++ b/dbt/adapters/clickhouse/httpclient.py
@@ -66,6 +66,8 @@ class ChHttpClient(ChClientWrapper):
                 send_receive_timeout=credentials.send_receive_timeout,
                 client_name=f'dbt-adapters/{dbt_adapters_version} dbt-clickhouse/{dbt_clickhouse_version}',
                 verify=credentials.verify,
+                client_cert=credentials.client_cert,
+                client_cert_key=credentials.client_cert_key,
                 query_limit=0,
                 settings=self._conn_settings,
             )

--- a/dbt/adapters/clickhouse/nativeclient.py
+++ b/dbt/adapters/clickhouse/nativeclient.py
@@ -68,6 +68,8 @@ class ChNativeClient(ChClientWrapper):
             client_name=f'dbt-adapters/{dbt_adapters_version} dbt-clickhouse/{dbt_clickhouse_version} clickhouse-driver/{driver_version}',
             secure=credentials.secure,
             verify=credentials.verify,
+            certfile=credentials.client_cert,
+            keyfile=credentials.client_cert_key,
             connect_timeout=credentials.connect_timeout,
             send_receive_timeout=credentials.send_receive_timeout,
             sync_request_timeout=credentials.sync_request_timeout,


### PR DESCRIPTION
## Summary

Exposes the TLS client certificate settings from `clickhouse-connect`/`clickhouse-driver` as profile parameters.

## Checklist

Delete items not relevant to your PR:

- [ ] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG