### PR TITLE
fix[s3 source]: allow for global or model config level definition of the role_arn

### DIFF
--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -281,6 +281,7 @@ class ClickHouseAdapter(SQLAdapter):
         if comp:
             comp = f"', {comp}'"
         extra_credentials = ''
+        role_arn = role_arn or s3config.get('role_arn')
         if role_arn:
             extra_credentials = f", extra_credentials(role_arn='{role_arn}')"
         return f"s3('{url}'{access}, '{fmt}'{struct}{comp}{extra_credentials})"


### PR DESCRIPTION
## Summary
Added `role_arn` to be configurable at the project or model level

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
