### PR TITLE
fix quoting reference in database_engine usage

### DIFF
--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -176,7 +176,9 @@ class ClickHouseAdapter(SQLAdapter):
     def should_on_cluster(self, materialized: str = '', engine: str = '') -> bool:
         conn = self.connections.get_if_exists()
         if conn and conn.credentials.cluster:
-            return ClickHouseRelation.get_on_cluster(conn.credentials.cluster, materialized, engine, conn.credentials.database_engine)
+            return ClickHouseRelation.get_on_cluster(
+                conn.credentials.cluster, materialized, engine, conn.credentials.database_engine
+            )
         return ClickHouseRelation.get_on_cluster('', materialized, engine)
 
     @available.parse_none

--- a/dbt/adapters/clickhouse/relation.py
+++ b/dbt/adapters/clickhouse/relation.py
@@ -92,7 +92,11 @@ class ClickHouseRelation(BaseRelation):
 
     @classmethod
     def get_on_cluster(
-        cls: Type[Self], cluster: str = '', materialized: str = '', engine: str = '', database_engine: str = ''
+        cls: Type[Self],
+        cluster: str = '',
+        materialized: str = '',
+        engine: str = '',
+        database_engine: str = '',
     ) -> bool:
         if 'replicated' in database_engine.lower():
             return False

--- a/dbt/adapters/clickhouse/relation.py
+++ b/dbt/adapters/clickhouse/relation.py
@@ -129,6 +129,7 @@ class ClickHouseRelation(BaseRelation):
 
         can_on_cluster = None
         cluster = ""
+        database_engine = ""
         # We placed a hardcoded const (instead of importing it from dbt-core) in order to decouple the packages
         if relation_config.resource_type == NODE_TYPE_SOURCE:
             if schema == relation_config.source_name and relation_config.database:
@@ -136,6 +137,7 @@ class ClickHouseRelation(BaseRelation):
         else:
             # quoting is only available for non-source nodes
             cluster = quoting.credentials.cluster or ""
+            database_engine = quoting.credentials.database_engine
 
         if cluster and str(relation_config.config.get("force_on_cluster")).lower() == "true":
             can_on_cluster = True
@@ -143,7 +145,6 @@ class ClickHouseRelation(BaseRelation):
         else:
             materialized = relation_config.config.get('materialized') or ''
             engine = relation_config.config.get('engine') or ''
-            database_engine = quoting.credentials.database_engine or ''
             can_on_cluster = cls.get_on_cluster(cluster, materialized, engine, database_engine)
 
         return cls.create(

--- a/tests/integration/adapter/clickhouse/test_clickhouse_table_ttl.py
+++ b/tests/integration/adapter/clickhouse/test_clickhouse_table_ttl.py
@@ -86,19 +86,19 @@ class TestDistributedTableTTL:
         return {
             "id_expire.sql": DISTRIBUTED_TABLE_TTL_MODEL,
         }
-    
+
     def test_base(self, project):
         results = run_dbt()
         assert len(results) == 1
-        
+
         relation = relation_from_name(project.adapter, "id_expire")
         relation_local = relation_from_name(project.adapter, "id_expire_local")
-        
+
         # wait for TTL to expire
         time.sleep(6)
-        
+
         project.run_sql(f"OPTIMIZE TABLE {relation_local} FINAL")
-        
+
         # make sure is empty
         cnt = project.run_sql(f"select count(*) from {relation}", fetch="all")
         assert cnt[0][0] == 0

--- a/tests/integration/adapter/replicated_database/test_replicated_database.py
+++ b/tests/integration/adapter/replicated_database/test_replicated_database.py
@@ -1,8 +1,7 @@
 import pytest
-
-from dbt.tests.adapter.basic.test_incremental import BaseIncremental
-from dbt.tests.adapter.basic.test_base import BaseSimpleMaterializations
 from dbt.tests.adapter.basic.files import model_incremental, schema_base_yml
+from dbt.tests.adapter.basic.test_base import BaseSimpleMaterializations
+from dbt.tests.adapter.basic.test_incremental import BaseIncremental
 
 
 class TestReplicatedDatabaseSimpleMaterialization(BaseSimpleMaterializations):

--- a/tests/integration/adapter/replicated_database/test_replicated_database.py
+++ b/tests/integration/adapter/replicated_database/test_replicated_database.py
@@ -6,16 +6,21 @@ from dbt.tests.adapter.basic.test_incremental import BaseIncremental
 
 class TestReplicatedDatabaseSimpleMaterialization(BaseSimpleMaterializations):
     """Contains tests for table, view and swappable view materialization."""
+
     @pytest.fixture(scope="class")
     def test_config(self, test_config):
-        test_config["db_engine"] = "Replicated('/clickhouse/databases/{uuid}', '{shard}', '{replica}')"
+        test_config["db_engine"] = (
+            "Replicated('/clickhouse/databases/{uuid}', '{shard}', '{replica}')"
+        )
         return test_config
 
 
 class TestReplicatedDatabaseIncremental(BaseIncremental):
     @pytest.fixture(scope="class")
     def test_config(self, test_config):
-        test_config["db_engine"] = "Replicated('/clickhouse/databases/{uuid}', '{shard}', '{replica}')"
+        test_config["db_engine"] = (
+            "Replicated('/clickhouse/databases/{uuid}', '{shard}', '{replica}')"
+        )
         return test_config
 
     @pytest.fixture(scope="class")


### PR DESCRIPTION
## Summary
When pushing #407, many tests were failing because of the `quoating` usage (quoting is only available for non-source nodes)

