### PR TITLE
Fix on cluster clause behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@
 ### Improvements
 * Upgrade `dbt-core` to version `1.9` and `dbt-adapters` to `>=1.10` ([#403](https://github.com/ClickHouse/dbt-clickhouse/pull/403))
 * Previously, delete_insert would fall back to legacy silently. Now it raises an error if LWD is not enabled.
+* Refactored the logic for applying the `ON CLUSTER` clause during model creation.
+    - Previously, `ON CLUSTER` was inconsistently applied based on engine type and materialization, often leading to confusion and unexpected results.
+    - Now, if a `cluster` is defined in the profile and the engine is **not** `Replicated`, the `ON CLUSTER` clause will **always** be added by default.
+    - A new model-level config `disable_on_cluster: true` has been introduced to explicitly opt out of this behavior.
+    - ⚠️ **Breaking Change**: This modifies the previous behavior. Users relying on the old implicit logic should review and update their models accordingly.
+
 
 ### Release [1.8.9], 2025-02-16
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This plugin ports [dbt](https://getdbt.com) functionality to [Clickhouse](https:
 
 The plugin uses syntax that requires ClickHouse version 22.1 or newer. We do not test older versions of Clickhouse. We
 also do not currently test
-Replicated tables or the related `ON CLUSTER` functionality.
+Replicated tables.
 
 ## Installation
 
@@ -169,25 +169,24 @@ The `cluster` setting in profile enables dbt-clickhouse to run against a ClickHo
 
 ### Effective Scope
 
-if `cluster` is set in profile, `on_cluster_clause` now will return cluster info for:
+If `cluster` is set in the profile, **all models will be created with the `ON CLUSTER` clause** by default—except for those using a **Replicated** engine. This includes:
 
 - Database creation
-- View materialization
+- View materializations
+- Table and incremental materializations
 - Distributed materializations
-- Models with Replicated engines
 
+Replicated engines will **not** include the `ON CLUSTER` clause, as they are designed to manage replication internally.
 
-By default, tables and incremental materializations with non-replicated engines will not be affected by the `cluster` setting (model would be created on the connected node only).
+To **opt out** of cluster-based creation for a specific model, add the `disable_on_cluster` config:
 
-To force relations to be created on a cluster regardless of their engine or materialization, use the `force_on_cluster` argument:
 ```sql
 {{ config(
-        engine='Null',
-        materialized='materialized_view',
-        force_on_cluster='true'
+        engine='MergeTree',
+        materialized='table',
+        disable_on_cluster='true'
     )
 }}
-```
 
 table and incremental materializations with non-replicated engine will not be affected by `cluster` setting (model would
 be created on the connected node only).

--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -177,9 +177,9 @@ class ClickHouseAdapter(SQLAdapter):
         conn = self.connections.get_if_exists()
         if conn and conn.credentials.cluster:
             return ClickHouseRelation.get_on_cluster(
-                conn.credentials.cluster, materialized, engine, conn.credentials.database_engine
+                cluster=conn.credentials.cluster, database_engine=conn.credentials.database_engine
             )
-        return ClickHouseRelation.get_on_cluster('', materialized, engine)
+        return ClickHouseRelation.get_on_cluster()
 
     @available.parse_none
     def calculate_incremental_strategy(self, strategy: str) -> str:

--- a/dbt/adapters/clickhouse/relation.py
+++ b/dbt/adapters/clickhouse/relation.py
@@ -70,7 +70,9 @@ class ClickHouseRelation(BaseRelation):
     def derivative(self, suffix: str, relation_type: Optional[str] = None) -> BaseRelation:
         path = Path(schema=self.path.schema, database='', identifier=self.path.identifier + suffix)
         derivative_type = ClickHouseRelationType(relation_type) if relation_type else self.type
-        return ClickHouseRelation(type=derivative_type, path=path)
+        return ClickHouseRelation(
+            type=derivative_type, path=path, can_on_cluster=self.can_on_cluster
+        )
 
     def matches(
         self,

--- a/dbt/include/clickhouse/macros/materializations/snapshot.sql
+++ b/dbt/include/clickhouse/macros/materializations/snapshot.sql
@@ -27,7 +27,7 @@
 
   {%- set upsert = target.derivative('__snapshot_upsert') -%}
   {% call statement('create_upsert_relation') %}
-    create table if not exists {{ upsert }} as {{ target }}
+    create table if not exists {{ upsert }} {{ on_cluster_clause(upsert) }} as {{ target }}
   {% endcall %}
 
   {% call statement('insert_unchanged_data') %}

--- a/tests/integration/adapter/clickhouse/test_clickhouse_table_materializations.py
+++ b/tests/integration/adapter/clickhouse/test_clickhouse_table_materializations.py
@@ -251,26 +251,23 @@ class TestReplicatedTableMaterialization(BaseSimpleMaterializations):
         self.assert_total_count_correct(project)
 
 
-class TestMergeTreeForceClusterMaterialization(BaseSimpleMaterializations):
-    '''Test MergeTree materialized view is created across a cluster using the
-    `force_on_cluster` config argument
-    '''
-
-    @pytest.fixture(scope="class")
-    def models(self):
-        config_force_on_cluster = """
+default_cluster_materialized_config = """
             {{ config(
                 engine='MergeTree',
-                materialized='materialized_view',
-                force_on_cluster='true'
-                )
-            }}
+                materialized='materialized_view'
+            ) }}
         """
+models_disable_on_cluster_config = """
+    {{ config(
+                engine='MergeTree',
+                materialized='materialized_view',
+                disable_on_cluster='true'
+            ) }}
+"""
 
-        return {
-            "force_on_cluster.sql": config_force_on_cluster + model_base,
-            "schema.yml": schema_base_yml,
-        }
+
+class TestMergeTreeDisableClusterMaterialization:
+    '''Test MergeTree materialized view optionally created across cluster using disable_on_cluster config'''
 
     @pytest.fixture(scope="class")
     def seeds(self):
@@ -279,75 +276,39 @@ class TestMergeTreeForceClusterMaterialization(BaseSimpleMaterializations):
             "base.csv": seeds_base_csv,
         }
 
-    def assert_total_count_correct(self, project):
-        '''Check if table is created on cluster'''
-        cluster = project.test_config['cluster']
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "default_cluster_materialized.sql": default_cluster_materialized_config + model_base,
+            "disable_cluster_materialized.sql": models_disable_on_cluster_config + model_base,
+            "schema.yml": schema_base_yml,
+        }
 
-        # check if data is properly distributed/replicated
-        table_relation = relation_from_name(project.adapter, "force_on_cluster")
-        # ClickHouse cluster in the docker-compose file
-        # under tests/integration is configured with 3 nodes
-        host_count = project.run_sql(
-            f"select count(host_name) as host_count from system.clusters where cluster='{cluster}'",
-            fetch="one",
-        )
-        assert host_count[0] > 1
+    def assert_object_count_on_cluster(self, project, model_name, expected_count: int):
+        cluster = project.test_config['cluster']
+        table_relation = relation_from_name(project.adapter, model_name)
 
         table_count = project.run_sql(
             f"select count() From clusterAllReplicas('{cluster}', system.tables) "
             f"where database='{table_relation.schema}' and name='{table_relation.identifier}'",
             fetch="one",
         )
-
-        assert table_count[0] == 3
-
-        mv_count = project.run_sql(
-            f"select count() From clusterAllReplicas('{cluster}', system.tables) "
-            f"where database='{table_relation.schema}' and name='{table_relation.identifier}_mv'",
-            fetch="one",
-        )
-
-        assert mv_count[0] == 3
+        assert table_count[0] == expected_count
 
     @pytest.mark.skipif(
         os.environ.get('DBT_CH_TEST_CLUSTER', '').strip() == '', reason='Not on a cluster'
     )
-    def test_base(self, project):
-        # cluster setting must exist
-        cluster = project.test_config['cluster']
-        assert cluster
-
-        # seed command
-        results = run_dbt(["seed"])
-        # seed result length
+    def test_create_on_cluster_by_default(self, project):
+        run_dbt(["seed"])
+        results = run_dbt(["run", "--select", "default_cluster_materialized.sql"])
         assert len(results) == 1
+        self.assert_object_count_on_cluster(project, "default_cluster_materialized", 3)
 
-        # run command
-        results = run_dbt()
-        # run result length
+    @pytest.mark.skipif(
+        os.environ.get('DBT_CH_TEST_CLUSTER', '').strip() == '', reason='Not on a cluster'
+    )
+    def test_disable_on_cluster(self, project):
+        run_dbt(["seed"])
+        results = run_dbt(["run", "--select", "disable_cluster_materialized.sql"])
         assert len(results) == 1
-
-        # names exist in result nodes
-        check_result_nodes_by_name(results, ["force_on_cluster"])
-
-        # check relation types
-        expected = {
-            "base": "table",
-            "replicated": "table",
-        }
-        check_relation_types(project.adapter, expected)
-
-        relation = relation_from_name(project.adapter, "base")
-        # table rowcount
-        result = project.run_sql(f"select count(*) as num_rows from {relation}", fetch="one")
-        assert result[0] == 10
-
-        # relations_equal
-        self.assert_total_count_correct(project)
-
-        # run full refresh
-        results = run_dbt(['--debug', 'run', '--full-refresh'])
-        # run result length
-        assert len(results) == 1
-
-        self.assert_total_count_correct(project)
+        self.assert_object_count_on_cluster(project, "disable_cluster_materialized", 1)

--- a/tests/integration/adapter/clickhouse/test_clickhouse_table_ttl.py
+++ b/tests/integration/adapter/clickhouse/test_clickhouse_table_ttl.py
@@ -1,3 +1,4 @@
+import os
 import time
 from datetime import datetime
 
@@ -80,6 +81,9 @@ SELECT 3, toDateTime('2005-01-01 09:23:15')
 """
 
 
+@pytest.mark.skipif(
+    os.environ.get('DBT_CH_TEST_CLUSTER', '').strip() == '', reason='Not on a cluster'
+)
 class TestDistributedTableTTL:
     @pytest.fixture(scope="class")
     def models(self):

--- a/tests/integration/adapter/incremental/test_base_incremental.py
+++ b/tests/integration/adapter/incremental/test_base_incremental.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from dbt.tests.adapter.basic.files import model_incremental, schema_base_yml
 from dbt.tests.adapter.basic.test_incremental import BaseIncremental
@@ -263,6 +265,9 @@ insert_overwrite_replicated_inc = """
 """
 
 
+@pytest.mark.skipif(
+    os.environ.get('DBT_CH_TEST_CLUSTER', '').strip() == '', reason='Not on a cluster'
+)
 class TestInsertOverwriteReplicatedIncremental:
     @pytest.fixture(scope="class")
     def models(self):

--- a/tests/integration/adapter/projections/test_projections.py
+++ b/tests/integration/adapter/projections/test_projections.py
@@ -87,7 +87,7 @@ class TestProjections:
 
     def test_create_and_verify_projection(self, project):
         run_dbt(["seed"])
-        run_dbt()
+        run_dbt(["run", "--select", "people_with_projection"])
 
         relation = relation_from_name(project.adapter, "people_with_projection")
         unique_query_identifier = str(uuid.uuid4())
@@ -117,7 +117,7 @@ class TestProjections:
 
     def test_create_and_verify_multiple_projections(self, project):
         run_dbt(["seed"])
-        run_dbt()
+        run_dbt(["run", "--select", "people_with_multiple_projections"])
 
         relation = relation_from_name(project.adapter, "people_with_multiple_projections")
 


### PR DESCRIPTION
## Summary
This PR refactors the logic around how the ON CLUSTER clause is applied during model creation in the dbt ClickHouse adapter. The motivation stems from ongoing confusion and inconsistency in how ON CLUSTER is handled, as documented in issues like #237, #225, #336, #327, #328, #384, and #307.

Close #417 

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [x] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
