### PR TITLE
Add newline around subquery parenthesis used when contract is enabled

### DIFF
--- a/dbt/include/clickhouse/macros/materializations/table.sql
+++ b/dbt/include/clickhouse/macros/materializations/table.sql
@@ -237,7 +237,7 @@
     -- Use a subquery to get columns in the right order
           SELECT {{ dest_cols_csv }}
           FROM (
-            {{ sql }} 
+            {{ sql }}
             )
   {%- else -%}
       {{ sql }}

--- a/dbt/include/clickhouse/macros/materializations/table.sql
+++ b/dbt/include/clickhouse/macros/materializations/table.sql
@@ -235,7 +235,10 @@
         ({{ dest_cols_csv }})
   {%- if has_contract -%}
     -- Use a subquery to get columns in the right order
-          SELECT {{ dest_cols_csv }} FROM ( {{ sql }} )
+          SELECT {{ dest_cols_csv }}
+          FROM (
+            {{ sql }} 
+            )
   {%- else -%}
       {{ sql }}
   {%- endif -%}


### PR DESCRIPTION
## Summary

As reported in [this issue](https://github.com/ClickHouse/dbt-clickhouse/issues/456), when the last line of a model's SQL query is a comment (`-- some comment`) and the table's contract is enforced, the last parenthesis of the wrapping subquery ends up commented as well.

In order to solve the issue, I'm adding newlines around the wrapping parenthesis.
