### PR TITLE
Check for `Shared` database engine in `can_exchange`

### DIFF
--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -170,7 +170,7 @@ class ClickHouseAdapter(SQLAdapter):
         if rel_type != 'table' or not schema or not self.supports_atomic_exchange():
             return False
         ch_db = self.get_ch_database(schema)
-        return ch_db and ch_db.engine in ('Atomic', 'Replicated')
+        return ch_db and ch_db.engine in ('Atomic', 'Replicated', 'Shared')
 
     @available.parse_none
     def should_on_cluster(self, materialized: str = '', engine: str = '') -> bool:


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

Check for `Shared` database engine in `can_exchange` (for SharedCatalog). See https://clickhouse-inc.slack.com/archives/C03P2UB2NEB/p1748015555369729?thread_ts=1747039049.389849&cid=C03P2UB2NEB

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
