### PR TITLE
allow using ca_cert parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Release [x.x.x]
+
+#### Improvements
+* Add Certificate Authority root support for httpclient and nativeclient using `ca_cert` parameter
+
 ### Release [1.9.0], 2025-04-28
 
 #### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 #### Improvements
 * Add Certificate Authority root support for httpclient and nativeclient using `ca_cert` parameter
 
+### Release [1.9.2], 2025-06-03
+
+#### Bugs
+* Limit dbt-core version to <1.10.X to avoid compatibility issues ([#453](https://github.com/ClickHouse/dbt-clickhouse/pull/453))
+* README file was broken and fixed in ([#454](https://github.com/ClickHouse/dbt-clickhouse/pull/454))
+* Snapshots were not worked properly on cluster, fixed in ([#455](https://github.com/ClickHouse/dbt-clickhouse/pull/455))
+* when the last line of a model's SQL query is a comment (-- some comment) and the table's contract is enforced, the last parenthesis of the wrapping subquery ends up commented as well. Was fixed in ([#457](https://github.com/ClickHouse/dbt-clickhouse/pull/457))
+* Check for Shared database engine in can_exchange ([#460](https://github.com/ClickHouse/dbt-clickhouse/pull/460))
+* Tests were broken because of docker compose version `2.35` and fixed in ([#468](https://github.com/ClickHouse/dbt-clickhouse/pull/468))
+
+### Release [1.9.1], 2025-04-28
+
+#### Bugs
+* Fix missing database_engine error ([#450](https://github.com/ClickHouse/dbt-clickhouse/pull/450))
+
 ### Release [1.9.0], 2025-04-28
 
 #### New Features

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ your_profile_name:
       secure: [False] # Use TLS (native protocol) or HTTPS (http protocol)
       client_cert: [null] # Path to a TLS client certificate in .pem format
       client_cert_key: [null] # Path to the private key for the TLS client certificate
+      ca_cert: [null] # Path to Certificate Authority root to validate ClickHouse server certificate
       retries: [1] # Number of times to retry a "retriable" database exception (such as a 503 'Service Unavailable' error)
       compression: [<empty string>] # Use gzip compression if truthy (http), or compression type for a native connection
       connect_timeout: [10] # Timeout in seconds to establish a connection to ClickHouse

--- a/dbt/adapters/clickhouse/credentials.py
+++ b/dbt/adapters/clickhouse/credentials.py
@@ -26,6 +26,7 @@ class ClickHouseCredentials(Credentials):
     verify: bool = True
     client_cert: Optional[str] = None
     client_cert_key: Optional[str] = None
+    ca_cert: Optional[str] = None
     connect_timeout: int = 10
     send_receive_timeout: int = 300
     sync_request_timeout: int = 5
@@ -77,6 +78,7 @@ class ClickHouseCredentials(Credentials):
             'verify',
             'client_cert',
             'client_cert_key',
+            'ca_cert',
             'connect_timeout',
             'send_receive_timeout',
             'sync_request_timeout',

--- a/dbt/adapters/clickhouse/httpclient.py
+++ b/dbt/adapters/clickhouse/httpclient.py
@@ -68,6 +68,7 @@ class ChHttpClient(ChClientWrapper):
                 verify=credentials.verify,
                 client_cert=credentials.client_cert,
                 client_cert_key=credentials.client_cert_key,
+                ca_cert=credentials.ca_cert,
                 query_limit=0,
                 settings=self._conn_settings,
             )

--- a/dbt/adapters/clickhouse/nativeclient.py
+++ b/dbt/adapters/clickhouse/nativeclient.py
@@ -70,6 +70,7 @@ class ChNativeClient(ChClientWrapper):
             verify=credentials.verify,
             certfile=credentials.client_cert,
             keyfile=credentials.client_cert_key,
+            ca_certs=credentials.ca_cert,
             connect_timeout=credentials.connect_timeout,
             send_receive_timeout=credentials.send_receive_timeout,
             sync_request_timeout=credentials.sync_request_timeout,


### PR DESCRIPTION
## Summary
Relates to the [issue](https://github.com/ClickHouse/dbt-clickhouse/issues/459). This PR the problem of connecting to a Managed ClickHouse cluster whose server certificate is signed by an internal root Certificate Authority. Added support for the CA root in httpclient and nativeclient using the `ca_cert` parameter

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
