### PR TITLE
Fix docker compose concurrent issue

### DIFF
--- a/.github/workflows/test_matrix.yml
+++ b/.github/workflows/test_matrix.yml
@@ -1,7 +1,7 @@
 ---
 name: "test_matrix"
 
-on:  # yamllint disable-line rule:truthy
+on: # yamllint disable-line rule:truthy
   pull_request:
     branches: main
   push:
@@ -45,15 +45,13 @@ jobs:
           echo "TEST_SETTINGS_FILE=22_3" >> $GITHUB_ENV
           echo "DBT_CH_TEST_CH_VERSION=22.3" >> $GITHUB_ENV
 
+      # a fix until docker compose v2.36.0 will be the default version in the github runner
       - name: Install Docker Compose v2.36.0
         run: |
           sudo mkdir -p /usr/local/lib/docker/cli-plugins
           sudo curl -L "https://github.com/docker/compose/releases/download/v2.36.0/docker-compose-linux-x86_64" -o /usr/local/lib/docker/cli-plugins/docker-compose
           sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
           docker compose version
-
-      - name: Show Docker Compose version
-        run: docker compose version
 
       - name: Run ClickHouse Cluster Containers
         env:


### PR DESCRIPTION
## Summary

Docker compose version 2.35 had an issue with concurrent image pulling https://github.com/docker/compose/issues/12747 that was solved in version 2.36. We added a manual docker-compose installation until GitHub runners will include it by default.
