### PR TITLE
chore: Substitute deprecated pkg_resources

### DIFF
--- a/dbt/adapters/clickhouse/nativeclient.py
+++ b/dbt/adapters/clickhouse/nativeclient.py
@@ -1,7 +1,7 @@
 from typing import List
 
 import clickhouse_driver
-import pkg_resources
+from importlib.metadata import version, PackageNotFoundError
 from clickhouse_driver.errors import NetworkError, SocketTimeoutError
 from dbt.adapters.__about__ import version as dbt_adapters_version
 from dbt_common.exceptions import DbtDatabaseError
@@ -13,8 +13,8 @@ from dbt.adapters.clickhouse.logger import logger
 from dbt.adapters.clickhouse.util import hide_stack_trace
 
 try:
-    driver_version = pkg_resources.get_distribution('clickhouse-driver').version
-except pkg_resources.ResolutionError:
+    driver_version = version('clickhouse-driver')
+except PackageNotFoundError:
     driver_version = 'unknown'
 
 


### PR DESCRIPTION
## Summary

Substitute use of pkg_resource API with importlib.metadata

Fixes #470
