### PR TITLE
Small lint fixes: Missing yaml space. Fixed Black's "exclude" config

### DIFF
--- a/.github/workflows/test_matrix.yml
+++ b/.github/workflows/test_matrix.yml
@@ -1,7 +1,7 @@
 ---
 name: "test_matrix"
 
-on: # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
   pull_request:
     branches: main
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 .Python
 env*/
 venv*/
+.venv/
 dbt_env/
 build/
 develop-eggs/

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 check-black:
 	@echo "--> Running black checks"
-	@black --check --diff --exclude=venv .
+	@black --check --diff .
 
 check-isort:
 	@echo "--> Running isort checks"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 line-length = 100
 skip-string-normalization = true
 target-version = ['py310', 'py311', 'py312']
-exclude = '(\.eggs|\.git|\.mypy_cache|\.venv|venv|env|_build|build|build|dist|)'
+exclude = '(\.eggs|\.git|\.mypy_cache|\.venv|venv|env|_build|build|build|dist)'
 
 [tool.isort]
 line_length = 100


### PR DESCRIPTION
## Summary
Fix missing yaml space
```sh
--> Running yamllint checks
.github/workflows/test_matrix.yml
  4:5       warning  too few spaces before comment  (comments)
```

It looks like Black wasn't excluding files from my virtual environment (`.venv`, the default in PyCharm) even when it's already in the exclude list. The fix makes black correctly process the `exclude` config.

Executing `make check-black` before:
```sh
((.venv) ) ➜  dbt-clickhouse git:(ClickHouse/small-lint-fixes) ✗ time make check-black
--> Running black checks
All done! ✨ 🍰 ✨
4495 files would be left unchanged.
make check-black  84.35s user 4.75s system 1025% cpu 8.692 total
```

after:
```sh
((.venv) ) ➜  dbt-clickhouse git:(ClickHouse/small-lint-fixes) ✗ time make check-black
--> Running black checks
All done! ✨ 🍰 ✨
85 files would be left unchanged.
make check-black  1.92s user 0.67s system 392% cpu 0.658 total
```
