### PR TITLE
Correctly parse query_settings when a String is added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Release [x.x.x]
+
+#### Bugs
+* query_settings not being correctly read ([#240](https://github.com/ClickHouse/dbt-clickhouse/pull/497))
+
+
 ### Release [1.9.2], 2025-06-03
 
 #### Bugs


### PR DESCRIPTION
## Summary

Fixes #240: 
- When parsing query_settings, if the value is a string, quotes will get added.
- Also supports the workaround we suggested in https://github.com/ClickHouse/dbt-clickhouse/issues/240#issuecomment-1894692117 so this change would not break it. 


## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG
