### PR TITLE
Shared database to can_exchange

### DIFF
--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -345,7 +345,7 @@ class ClickHouseAdapter(SQLAdapter):
             can_exchange = (
                 conn_supports_exchange
                 and rel_type == ClickHouseRelationType.Table
-                and db_engine in ('Atomic', 'Replicated')
+                and db_engine in ('Atomic', 'Replicated', 'Shared')
             )
             can_on_cluster = (on_cluster >= 1) and db_engine != 'Replicated'
 


### PR DESCRIPTION
## Summary
Added `Shared` to databases in `can_exchange` in order to prevent full model recalculations if database is `Shared`
