### PR TITLE
Fix isort not working in Github Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,16 +18,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python 3.11
+      - name: Setup Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Upgrade Setuptools
         run: pip install --upgrade setuptools wheel
 
       - name: Install requirements
-        run: pip install -r dev_requirements.txt
+        run: |
+          pip install -r dev_requirements.txt
+          pip install .
 
       - name: Run lint
         run: make lint

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ check-black:
 
 check-isort:
 	@echo "--> Running isort checks"
-	@isort --check-only .
+	@isort --check-only --diff .
 
 check-mypy:
 	@echo "--> Running mypy checks"

--- a/dbt/adapters/clickhouse/__init__.py
+++ b/dbt/adapters/clickhouse/__init__.py
@@ -1,5 +1,4 @@
 from dbt.adapters.base import AdapterPlugin
-
 from dbt.adapters.clickhouse.column import ClickHouseColumn  # noqa
 from dbt.adapters.clickhouse.connections import ClickHouseConnectionManager  # noqa
 from dbt.adapters.clickhouse.credentials import ClickHouseCredentials

--- a/dbt/adapters/clickhouse/connections.py
+++ b/dbt/adapters/clickhouse/connections.py
@@ -4,11 +4,10 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Optional, Tuple, Union
 
 import dbt.exceptions
-from dbt.adapters.contracts.connection import AdapterResponse, Connection
-from dbt.adapters.sql import SQLConnectionManager
-
 from dbt.adapters.clickhouse.dbclient import ChRetryableException, get_db_client
 from dbt.adapters.clickhouse.logger import logger
+from dbt.adapters.contracts.connection import AdapterResponse, Connection
+from dbt.adapters.sql import SQLConnectionManager
 
 if TYPE_CHECKING:
     import agate

--- a/dbt/adapters/clickhouse/dbclient.py
+++ b/dbt/adapters/clickhouse/dbclient.py
@@ -3,9 +3,6 @@ import uuid
 from abc import ABC, abstractmethod
 from typing import Dict
 
-from dbt.adapters.exceptions import FailedToConnectError
-from dbt_common.exceptions import DbtConfigError, DbtDatabaseError
-
 from dbt.adapters.clickhouse.credentials import ClickHouseCredentials
 from dbt.adapters.clickhouse.errors import (
     lw_deletes_not_enabled_error,
@@ -16,6 +13,8 @@ from dbt.adapters.clickhouse.errors import (
 from dbt.adapters.clickhouse.logger import logger
 from dbt.adapters.clickhouse.query import quote_identifier
 from dbt.adapters.clickhouse.util import compare_versions
+from dbt.adapters.exceptions import FailedToConnectError
+from dbt_common.exceptions import DbtConfigError, DbtDatabaseError
 
 LW_DELETE_SETTING = 'allow_experimental_lightweight_delete'
 ND_MUTATION_SETTING = 'allow_nondeterministic_mutations'
@@ -50,7 +49,6 @@ def get_db_client(credentials: ClickHouseCredentials):
     if driver == 'native':
         try:
             import clickhouse_driver  # noqa
-
             from dbt.adapters.clickhouse.nativeclient import ChNativeClient
 
             return ChNativeClient(credentials)
@@ -60,7 +58,6 @@ def get_db_client(credentials: ClickHouseCredentials):
             ) from ex
     try:
         import clickhouse_connect  # noqa
-
         from dbt.adapters.clickhouse.httpclient import ChHttpClient
 
         return ChHttpClient(credentials)

--- a/dbt/adapters/clickhouse/httpclient.py
+++ b/dbt/adapters/clickhouse/httpclient.py
@@ -3,12 +3,11 @@ from typing import List
 import clickhouse_connect
 from clickhouse_connect.driver.exceptions import DatabaseError, OperationalError
 from dbt.adapters.__about__ import version as dbt_adapters_version
-from dbt_common.exceptions import DbtDatabaseError
-
 from dbt.adapters.clickhouse import ClickHouseColumn
 from dbt.adapters.clickhouse.__version__ import version as dbt_clickhouse_version
 from dbt.adapters.clickhouse.dbclient import ChClientWrapper, ChRetryableException
 from dbt.adapters.clickhouse.util import hide_stack_trace
+from dbt_common.exceptions import DbtDatabaseError
 
 
 class ChHttpClient(ChClientWrapper):

--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -20,14 +20,6 @@ from dbt.adapters.base import AdapterConfig, available
 from dbt.adapters.base.impl import BaseAdapter, ConstraintSupport
 from dbt.adapters.base.relation import BaseRelation, InformationSchema
 from dbt.adapters.capability import Capability, CapabilityDict, CapabilitySupport, Support
-from dbt.adapters.contracts.relation import Path, RelationConfig
-from dbt.adapters.events.types import ConstraintNotSupported
-from dbt.adapters.sql import SQLAdapter
-from dbt_common.contracts.constraints import ConstraintType, ModelLevelConstraint
-from dbt_common.events.functions import warn_or_error
-from dbt_common.exceptions import DbtInternalError, DbtRuntimeError, NotImplementedError
-from dbt_common.utils import filter_null_values
-
 from dbt.adapters.clickhouse.cache import ClickHouseRelationsCache
 from dbt.adapters.clickhouse.column import ClickHouseColumn, ClickHouseColumnChanges
 from dbt.adapters.clickhouse.connections import ClickHouseConnectionManager
@@ -40,6 +32,13 @@ from dbt.adapters.clickhouse.logger import logger
 from dbt.adapters.clickhouse.query import quote_identifier
 from dbt.adapters.clickhouse.relation import ClickHouseRelation, ClickHouseRelationType
 from dbt.adapters.clickhouse.util import compare_versions
+from dbt.adapters.contracts.relation import Path, RelationConfig
+from dbt.adapters.events.types import ConstraintNotSupported
+from dbt.adapters.sql import SQLAdapter
+from dbt_common.contracts.constraints import ConstraintType, ModelLevelConstraint
+from dbt_common.events.functions import warn_or_error
+from dbt_common.exceptions import DbtInternalError, DbtRuntimeError, NotImplementedError
+from dbt_common.utils import filter_null_values
 
 if TYPE_CHECKING:
     import agate
@@ -608,7 +607,7 @@ def _expect_row_value(key: str, row: "agate.Row"):
 
 
 def _catalog_filter_schemas(
-    used_schemas: FrozenSet[Tuple[str, str]]
+    used_schemas: FrozenSet[Tuple[str, str]],
 ) -> Callable[["agate.Row"], bool]:
     """Return a function that takes a row and decides if the row should be
     included in the catalog output.

--- a/dbt/adapters/clickhouse/nativeclient.py
+++ b/dbt/adapters/clickhouse/nativeclient.py
@@ -4,13 +4,12 @@ from typing import List
 import clickhouse_driver
 from clickhouse_driver.errors import NetworkError, SocketTimeoutError
 from dbt.adapters.__about__ import version as dbt_adapters_version
-from dbt_common.exceptions import DbtDatabaseError
-
 from dbt.adapters.clickhouse import ClickHouseColumn, ClickHouseCredentials
 from dbt.adapters.clickhouse.__version__ import version as dbt_clickhouse_version
 from dbt.adapters.clickhouse.dbclient import ChClientWrapper, ChRetryableException
 from dbt.adapters.clickhouse.logger import logger
 from dbt.adapters.clickhouse.util import hide_stack_trace
+from dbt_common.exceptions import DbtDatabaseError
 
 try:
     driver_version = version('clickhouse-driver')

--- a/dbt/adapters/clickhouse/relation.py
+++ b/dbt/adapters/clickhouse/relation.py
@@ -2,12 +2,11 @@ from dataclasses import dataclass, field
 from typing import Any, Optional, Type
 
 from dbt.adapters.base.relation import BaseRelation, EventTimeFilter, Path, Policy, Self
+from dbt.adapters.clickhouse.query import quote_identifier
 from dbt.adapters.contracts.relation import HasQuoting, RelationConfig
 from dbt_common.dataclass_schema import StrEnum
 from dbt_common.exceptions import DbtRuntimeError
 from dbt_common.utils import deep_merge
-
-from dbt.adapters.clickhouse.query import quote_identifier
 
 NODE_TYPE_SOURCE = 'source'
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -6,7 +6,7 @@ clickhouse-driver>=0.2.7
 pytest>=7.2.0
 pytest-dotenv==0.5.2
 pytest-timeout==2.4.0
-black==24.3.0
+black==25.1.0
 isort==6.0.1
 mypy==0.991
 yamllint==1.26.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ line_length = 100
 profile = "black"
 use_parentheses = true
 skip = '.eggs/,.mypy_cache/,.venv/,venv/,env/'
+known_third_party = ["pytest", "dbt"]
 
 [tool.pytest.ini_options]
 log_cli = true

--- a/tests/integration/adapter/materialized_view/test_materialized_view.py
+++ b/tests/integration/adapter/materialized_view/test_materialized_view.py
@@ -6,9 +6,9 @@ of materialized views from PostgreSQL or Oracle
 import json
 
 import pytest
+from dbt.adapters.clickhouse.query import quote_identifier
 from dbt.tests.util import check_relation_types, run_dbt
 
-from dbt.adapters.clickhouse.query import quote_identifier
 from tests.integration.adapter.helpers import below_version
 
 PEOPLE_SEED_CSV = """

--- a/tests/integration/adapter/materialized_view/test_multiple_materialized_views.py
+++ b/tests/integration/adapter/materialized_view/test_multiple_materialized_views.py
@@ -6,9 +6,9 @@ of materialized views from PostgreSQL or Oracle
 import json
 
 import pytest
+from dbt.adapters.clickhouse.query import quote_identifier
 from dbt.tests.util import check_relation_types, run_dbt
 
-from dbt.adapters.clickhouse.query import quote_identifier
 from tests.integration.adapter.helpers import below_version
 
 PEOPLE_SEED_CSV = """


### PR DESCRIPTION
Related to https://github.com/ClickHouse/dbt-clickhouse/issues/501

Happened while working on fixing https://github.com/ClickHouse/dbt-clickhouse/pull/504

To be honest I'm still not 100% sure about what was happening but isort wasn't working inside the workers.

In local it was (correctly) telling me to add one missing space
```
ERROR: /Users/josemunoz/repos/dbt-clickhouse/tests/integration/adapter/basic/test_engine_settings.py Imports are incorrectly sorted and/or formatted.
--- /Users/josemunoz/repos/dbt-clickhouse/tests/integration/adapter/basic/test_engine_settings.py:before        2025-09-04 16:43:24.652117
+++ /Users/josemunoz/repos/dbt-clickhouse/tests/integration/adapter/basic/test_engine_settings.py:after 2025-09-04 16:43:27.133033
@@ -1,4 +1,5 @@
 import pytest
+
 from dbt.tests.util import relation_from_name, run_dbt
```
And then inside the Github action it was telling me to remove it https://github.com/ClickHouse/dbt-clickhouse/actions/runs/17467788629/job/49607954601
```
ERROR: /home/runner/work/dbt-clickhouse/dbt-clickhouse/tests/integration/adapter/basic/test_engine_settings.py Imports are incorrectly sorted and/or formatted.
--- /home/runner/work/dbt-clickhouse/dbt-clickhouse/tests/integration/adapter/basic/test_engine_settings.py:before 2025-09-04 14:29:14.754085
+++ /home/runner/work/dbt-clickhouse/dbt-clickhouse/tests/integration/adapter/basic/test_engine_settings.py:after 2025-09-04 14:29:32.051409
@@ -1,5 +1,4 @@
 import pytest
-
 from dbt.tests.util import relation_from_name, run_dbt
 test_models_mergetree = """
```

Looks like the problem was that it wasn't correctly identifying the packages. Adding `known_third_party = ["pytest", "dbt"]` was the key part to fix it. Now it also fixes a lot of existing files that really needed to be resorted.