### PR TITLE
Fix cloud tests and problems with snapshots not using a consistent now()

### DIFF
--- a/.github/workflows/test_cloud.yml
+++ b/.github/workflows/test_cloud.yml
@@ -19,7 +19,7 @@ jobs:
   cloud_smt_tests:
     name: ClickHouse Cloud SharedMergeTree Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
 
     strategy:
       max-parallel: 1

--- a/.github/workflows/test_cloud.yml
+++ b/.github/workflows/test_cloud.yml
@@ -2,6 +2,10 @@
 name: "test_cloud"
 
 on:  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: '0 0 * * *'  # nightly run every day at 00:00 UTC
+  pull_request:
+    branches: main
   push:
     branches:
       - '*_cloud'

--- a/.github/workflows/test_cloud.yml
+++ b/.github/workflows/test_cloud.yml
@@ -7,8 +7,12 @@ on:  # yamllint disable-line rule:truthy
   pull_request:
     branches: main
   push:
-    branches:
-      - '*_cloud'
+    branches-ignore:
+      - '*_test'
+      - '*_dev'
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_cloud.yml
+++ b/.github/workflows/test_cloud.yml
@@ -20,6 +20,10 @@ jobs:
     name: ClickHouse Cloud SharedMergeTree Tests
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+
     env:
       PYTHONPATH: dbt
       DBT_CH_TEST_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
@@ -31,10 +35,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Python 3.11
+      - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install requirements
         run: pip3 install -r dev_requirements.txt

--- a/.github/workflows/test_cloud.yml
+++ b/.github/workflows/test_cloud.yml
@@ -2,30 +2,15 @@
 name: "test_cloud"
 
 on:  # yamllint disable-line rule:truthy
-  schedule:
-    - cron: '0 0 * * *'  # nightly run every day at 00:00 UTC
-  pull_request:
-    branches: main
   push:
-    branches-ignore:
-      - '*_test'
-      - '*_dev'
-    paths-ignore:
-      - '**.md'
-      - 'LICENSE'
+    branches:
+      - '*_cloud'
   workflow_dispatch:
 
 jobs:
   cloud_smt_tests:
     name: ClickHouse Cloud SharedMergeTree Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 90
-
-    strategy:
-      max-parallel: 1
-      fail-fast: false
-      matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     env:
       PYTHONPATH: dbt
@@ -38,10 +23,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Python ${{ matrix.python-version }}
+      - name: Setup Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.11'
 
       - name: Install requirements
         run: pip3 install -r dev_requirements.txt
@@ -49,9 +34,9 @@ jobs:
       - name: Run HTTP tests
         env:
           DBT_CH_TEST_PORT: 8443
-        run: pytest tests --timeout=120
+        run: pytest tests
 
       - name: Run Native tests
         env:
           DBT_CH_TEST_PORT: 9440
-        run: pytest tests --timeout=120
+        run: pytest tests

--- a/.github/workflows/test_cloud.yml
+++ b/.github/workflows/test_cloud.yml
@@ -19,9 +19,11 @@ jobs:
   cloud_smt_tests:
     name: ClickHouse Cloud SharedMergeTree Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     strategy:
       max-parallel: 1
+      fail-fast: false
       matrix:
         python-version: [ '3.9', '3.10', '3.11', '3.12' ]
 
@@ -47,9 +49,9 @@ jobs:
       - name: Run HTTP tests
         env:
           DBT_CH_TEST_PORT: 8443
-        run: pytest tests -n 8
+        run: pytest tests --timeout=120
 
       - name: Run Native tests
         env:
           DBT_CH_TEST_PORT: 9440
-        run: pytest tests -n 8
+        run: pytest tests --timeout=120

--- a/.github/workflows/test_cloud.yml
+++ b/.github/workflows/test_cloud.yml
@@ -47,9 +47,9 @@ jobs:
       - name: Run HTTP tests
         env:
           DBT_CH_TEST_PORT: 8443
-        run: pytest tests
+        run: pytest tests -n 8
 
       - name: Run Native tests
         env:
           DBT_CH_TEST_PORT: 9440
-        run: pytest tests
+        run: pytest tests -n 8

--- a/.github/workflows/test_cloud.yml
+++ b/.github/workflows/test_cloud.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      max-parallel: 1
       matrix:
         python-version: [ '3.9', '3.10', '3.11', '3.12' ]
 

--- a/.github/workflows/test_cloud.yml
+++ b/.github/workflows/test_cloud.yml
@@ -25,7 +25,7 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     env:
       PYTHONPATH: dbt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ### Release [1.9.3], 2025-09-08
 
 #### Bugs
-* Fix `query_settings` not being correctly read when values are strings ([#240](https://github.com/ClickHouse/dbt-clickhouse/pull/497)).
+* Fix `query_settings` not being correctly read when values are strings ([#497](https://github.com/ClickHouse/dbt-clickhouse/pull/497)).
 * Ensure that the default `replicated_deduplication_window` is only applied for `*MergeTree` engines ([#504](https://github.com/ClickHouse/dbt-clickhouse/pull/504)).
 * Avoid full model recalculation if database is `shared` ([#498](https://github.com/ClickHouse/dbt-clickhouse/pull/498)).
+* Override snapshot macro when working with timestamp strategy to allways get a consistent now() value ([#509](https://github.com/ClickHouse/dbt-clickhouse/pull/509)).
 * Use importlib instead of pkg_resources as it's now deprecated ([#471](https://github.com/ClickHouse/dbt-clickhouse/pull/471)).
 * Several fixes made to improve test execution. Most relevant ones:
   * Restore testing against different CH versions - all versions are now LTS ones, skip 25.8 until pending issue is fixed, fix tests on older versions ([c86a0889](https://github.com/ClickHouse/dbt-clickhouse/commit/c86a0889ad323ce0b02c7409275360e6f2202723)).

--- a/dbt/include/clickhouse/macros/materializations/snapshot.sql
+++ b/dbt/include/clickhouse/macros/materializations/snapshot.sql
@@ -86,3 +86,246 @@
 
   {% do return ('select 1') %}
 {% endmacro %}
+
+
+{% macro clickhouse__snapshot_staging_table(strategy, source_sql, target_relation) -%}
+    {# Detect strategy type and delegate to specific macro #}
+    {% if strategy.updated_at == 'now()' or 'now()' in strategy.updated_at %}
+        {{ clickhouse__snapshot_staging_table_check_strategy(strategy, source_sql, target_relation) }}
+    {% else %}
+        {{ clickhouse__snapshot_staging_table_timestamp_strategy(strategy, source_sql, target_relation) }}
+    {% endif %}
+{%- endmacro %}
+
+{% macro clickhouse__snapshot_staging_table_check_strategy(strategy, source_sql, target_relation) -%}
+
+    with snapshot_time as (
+        select {{ strategy.updated_at }} as ts  -- Single timestamp
+    ),
+        snapshot_query as (
+
+        {{ source_sql }}
+
+    ),
+
+    snapshotted_data as (
+
+        select *,
+            {{ strategy.unique_key }} as dbt_unique_key
+
+        from {{ target_relation }}
+        where dbt_valid_to is null
+
+    ),
+
+    insertions_source_data as (
+
+        select
+            *,
+            {{ strategy.unique_key }} as dbt_unique_key,
+            snapshot_time.ts as dbt_updated_at,
+            snapshot_time.ts as dbt_valid_from,
+            nullif(snapshot_time.ts, snapshot_time.ts) as dbt_valid_to,
+            {{ strategy.scd_id }} as dbt_scd_id
+
+        from snapshot_query, snapshot_time
+    ),
+
+    updates_source_data as (
+
+        select
+            *,
+            {{ strategy.unique_key }} as dbt_unique_key,
+            snapshot_time.ts as dbt_updated_at,
+            snapshot_time.ts as dbt_valid_from,
+            snapshot_time.ts as dbt_valid_to
+
+        from snapshot_query, snapshot_time
+    ),
+
+    {%- if strategy.invalidate_hard_deletes %}
+
+    deletes_source_data as (
+
+        select
+            *,
+            {{ strategy.unique_key }} as dbt_unique_key
+        from snapshot_query
+    ),
+    {% endif %}
+
+    insertions as (
+
+        select
+            'insert' as dbt_change_type,
+            source_data.*
+
+        from insertions_source_data as source_data
+        left outer join snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key
+        where snapshotted_data.dbt_unique_key is null
+           or (
+                snapshotted_data.dbt_unique_key is not null
+            and (
+                {{ strategy.row_changed }}
+            )
+        )
+
+    ),
+
+    updates as (
+
+        select
+            'update' as dbt_change_type,
+            source_data.*,
+            snapshotted_data.dbt_scd_id
+
+        from updates_source_data as source_data
+        join snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key
+        where (
+            {{ strategy.row_changed }}
+        )
+    )
+
+    {%- if strategy.invalidate_hard_deletes -%}
+    ,
+
+    deletes as (
+
+        select
+            'delete' as dbt_change_type,
+            source_data.*,
+            {{ snapshot_get_time() }} as dbt_valid_from,
+            {{ snapshot_get_time() }} as dbt_updated_at,
+            {{ snapshot_get_time() }} as dbt_valid_to,
+            snapshotted_data.dbt_scd_id
+
+        from snapshotted_data
+        left join deletes_source_data as source_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key
+        where source_data.dbt_unique_key is null
+    )
+    {%- endif %}
+
+    select * EXCEPT (ts) from insertions
+    union all
+    select * EXCEPT (ts) from updates
+    {%- if strategy.invalidate_hard_deletes %}
+    union all
+    select * EXCEPT (ts) from deletes
+    {%- endif %}
+
+{%- endmacro %}
+
+{% macro clickhouse__snapshot_staging_table_timestamp_strategy(strategy, source_sql, target_relation) -%}
+
+    with snapshot_query as (
+
+        {{ source_sql }}
+
+    ),
+
+    snapshotted_data as (
+
+        select *,
+            {{ strategy.unique_key }} as dbt_unique_key
+
+        from {{ target_relation }}
+        where dbt_valid_to is null
+
+    ),
+
+    insertions_source_data as (
+
+        select
+            *,
+            {{ strategy.unique_key }} as dbt_unique_key,
+            {{ strategy.updated_at }} as dbt_updated_at,
+            {{ strategy.updated_at }} as dbt_valid_from,
+            nullif({{ strategy.updated_at }}, {{ strategy.updated_at }}) as dbt_valid_to,
+            {{ strategy.scd_id }} as dbt_scd_id
+
+        from snapshot_query
+    ),
+
+    updates_source_data as (
+
+        select
+            *,
+            {{ strategy.unique_key }} as dbt_unique_key,
+            {{ strategy.updated_at }} as dbt_updated_at,
+            {{ strategy.updated_at }} as dbt_valid_from,
+            {{ strategy.updated_at }} as dbt_valid_to
+
+        from snapshot_query
+    ),
+
+    {%- if strategy.invalidate_hard_deletes %}
+
+    deletes_source_data as (
+
+        select
+            *,
+            {{ strategy.unique_key }} as dbt_unique_key
+        from snapshot_query
+    ),
+    {% endif %}
+
+    insertions as (
+
+        select
+            'insert' as dbt_change_type,
+            source_data.*
+
+        from insertions_source_data as source_data
+        left outer join snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key
+        where snapshotted_data.dbt_unique_key is null
+           or (
+                snapshotted_data.dbt_unique_key is not null
+            and (
+                {{ strategy.row_changed }}
+            )
+        )
+
+    ),
+
+    updates as (
+
+        select
+            'update' as dbt_change_type,
+            source_data.*,
+            snapshotted_data.dbt_scd_id
+
+        from updates_source_data as source_data
+        join snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key
+        where (
+            {{ strategy.row_changed }}
+        )
+    )
+
+    {%- if strategy.invalidate_hard_deletes -%}
+    ,
+
+    deletes as (
+
+        select
+            'delete' as dbt_change_type,
+            source_data.*,
+            {{ snapshot_get_time() }} as dbt_valid_from,
+            {{ snapshot_get_time() }} as dbt_updated_at,
+            {{ snapshot_get_time() }} as dbt_valid_to,
+            snapshotted_data.dbt_scd_id
+
+        from snapshotted_data
+        left join deletes_source_data as source_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key
+        where source_data.dbt_unique_key is null
+    )
+    {%- endif %}
+
+    select * from insertions
+    union all
+    select * from updates
+    {%- if strategy.invalidate_hard_deletes %}
+    union all
+    select * from deletes
+    {%- endif %}
+
+{%- endmacro %}

--- a/tests/integration/adapter/dictionary/test_dictionary.py
+++ b/tests/integration/adapter/dictionary/test_dictionary.py
@@ -4,6 +4,7 @@ test dictionary support in dbt-clickhouse
 
 import json
 import os
+import time
 
 import pytest
 from dbt.tests.util import run_dbt
@@ -175,6 +176,9 @@ class TestQueryDictionary:
         )
         # force the dictionary to be rebuilt to include the new records in `people`
         project.run_sql("system reload dictionary hackers")
+
+        if os.environ.get('DBT_CH_TEST_CLOUD', '').lower() in ('1', 'true', 'yes'):
+            time.sleep(30)
         result = project.run_sql("select count(distinct id) from hackers", fetch="all")
         assert result[0][0] == 5
 

--- a/tests/integration/adapter/materialized_view/test_refreshable_materialized_view.py
+++ b/tests/integration/adapter/materialized_view/test_refreshable_materialized_view.py
@@ -31,11 +31,11 @@ MV_MODEL = """
        order_by='(department)',
        refreshable=(
            {
-               "interval": "EVERY 1 DAY",
+               "interval": "EVERY 2 MINUTE",
                "depends_on": ['depend_on_model'],
                "depends_on_validation": True
            } if var('run_type', '') == 'validate_depends_on' else {
-               "interval": "EVERY 1 DAY"
+               "interval": "EVERY 2 MINUTE"
            }
        )
        )
@@ -122,13 +122,14 @@ class TestBasicRefreshableMV:
                 fetch="all",
             )
             statuses = [row[1] for row in result]
-            assert 'Scheduled' in statuses
+            assert 'Scheduled' in statuses or 'Running' in statuses
         else:
             result = project.run_sql(
                 f"select database, view, status from system.view_refreshes where database= '{project.test_schema}' and view='hackers_mv'",
                 fetch="all",
             )
-            assert result[0][2] == 'Scheduled'
+            mv_status = result[0][2]
+            assert mv_status in ('Scheduled', 'Running')
 
     def test_validate_dependency(self, project):
         """

--- a/tests/integration/adapter/materialized_view/test_refreshable_materialized_view.py
+++ b/tests/integration/adapter/materialized_view/test_refreshable_materialized_view.py
@@ -31,11 +31,11 @@ MV_MODEL = """
        order_by='(department)',
        refreshable=(
            {
-               "interval": "EVERY 2 MINUTE",
+               "interval": "EVERY 1 DAY",
                "depends_on": ['depend_on_model'],
                "depends_on_validation": True
            } if var('run_type', '') == 'validate_depends_on' else {
-               "interval": "EVERY 2 MINUTE"
+               "interval": "EVERY 1 DAY"
            }
        )
        )

--- a/tests/integration/adapter/materialized_view/test_refreshable_materialized_view.py
+++ b/tests/integration/adapter/materialized_view/test_refreshable_materialized_view.py
@@ -4,6 +4,7 @@ of materialized views from PostgreSQL or Oracle
 """
 
 import json
+import os
 
 import pytest
 from dbt.tests.util import check_relation_types, run_dbt
@@ -107,11 +108,24 @@ class TestBasicRefreshableMV:
             },
         )
 
-        result = project.run_sql(
-            f"select database, view, status from system.view_refreshes where database= '{project.test_schema}' and view='hackers_mv'",
-            fetch="all",
-        )
-        assert result[0][2] == 'Scheduled'
+        if os.environ.get('DBT_CH_TEST_CLOUD', '').lower() in ('1', 'true', 'yes'):
+            result = project.run_sql(f"""
+                        SELECT 
+                            hostName() as replica,
+                            status,
+                            last_refresh_time
+                        FROM clusterAllReplicas('default', 'system', 'view_refreshes')
+                        WHERE database = '{project.test_schema}' 
+                          AND view = 'hackers_mv'
+                    """, fetch="all")
+            statuses = [row[1] for row in result]
+            assert 'Scheduled' in statuses
+        else:
+            result = project.run_sql(
+                f"select database, view, status from system.view_refreshes where database= '{project.test_schema}' and view='hackers_mv'",
+                fetch="all",
+            )
+            assert result[0][2] == 'Scheduled'
 
     def test_validate_dependency(self, project):
         """

--- a/tests/integration/adapter/materialized_view/test_refreshable_materialized_view.py
+++ b/tests/integration/adapter/materialized_view/test_refreshable_materialized_view.py
@@ -109,7 +109,8 @@ class TestBasicRefreshableMV:
         )
 
         if os.environ.get('DBT_CH_TEST_CLOUD', '').lower() in ('1', 'true', 'yes'):
-            result = project.run_sql(f"""
+            result = project.run_sql(
+                f"""
                         SELECT 
                             hostName() as replica,
                             status,
@@ -117,7 +118,9 @@ class TestBasicRefreshableMV:
                         FROM clusterAllReplicas('default', 'system', 'view_refreshes')
                         WHERE database = '{project.test_schema}' 
                           AND view = 'hackers_mv'
-                    """, fetch="all")
+                    """,
+                fetch="all",
+            )
             statuses = [row[1] for row in result]
             assert 'Scheduled' in statuses
         else:

--- a/tests/integration/adapter/projections/test_projections.py
+++ b/tests/integration/adapter/projections/test_projections.py
@@ -66,6 +66,8 @@ sources:
       - name: people
 """
 
+SLEEP_TIME = 30 if os.environ.get('DBT_CH_TEST_CLOUD', '').lower() in ('1', 'true', 'yes') else 10
+
 
 class TestProjections:
     @pytest.fixture(scope="class")
@@ -100,14 +102,14 @@ class TestProjections:
         assert len(result) == 3  # We expect 3 departments in the result
         assert result == [('engineering', 43.666666666666664), ('malware', 40.0), ('sales', 25.0)]
 
-        # waiting for system.log table to be created
-        time.sleep(10)
+        # waiting for system.log table to be created/populated
+        time.sleep(SLEEP_TIME)
 
         # check that the latest query used the projection
         result = project.run_sql(
             f"SELECT query, projections FROM clusterAllReplicas(default, 'system.query_log') "
             f"WHERE query like '%{unique_query_identifier}%' "
-            f"and query not like '%system.query_log%' and read_rows > 0 ORDER BY query_start_time DESC",
+            f"and query not like '%clusterAllReplicas%' and query not like '%system.query_log%' and read_rows > 0 ORDER BY query_start_time DESC",
             fetch="all",
         )
         assert len(result) > 0
@@ -132,14 +134,14 @@ class TestProjections:
         assert len(result) == 3  # We expect 3 departments in the result
         assert result == [('engineering', 43.666666666666664), ('malware', 40.0), ('sales', 25.0)]
 
-        # waiting for system.log table to be created
-        time.sleep(10)
+        # waiting for system.log table to be created/populated
+        time.sleep(SLEEP_TIME)
 
         # check that the latest query used the projection
         result = project.run_sql(
             f"SELECT query, projections FROM clusterAllReplicas(default, 'system.query_log') "
             f"WHERE query like '%{unique_query_identifier}%' "
-            f"and query not like '%system.query_log%' and read_rows > 0 ORDER BY query_start_time DESC",
+            f"and query not like '%clusterAllReplicas%' and query not like '%system.query_log%' and read_rows > 0 ORDER BY query_start_time DESC",
             fetch="all",
         )
         assert len(result) > 0
@@ -158,14 +160,14 @@ class TestProjections:
         assert len(result) == 3  # We expect 3 departments in the result
         assert result == [('engineering', 131), ('malware', 40), ('sales', 25)]
 
-        # waiting for system.log table to be created
-        time.sleep(10)
+        # waiting for system.log table to be created/populated
+        time.sleep(SLEEP_TIME)
 
         # check that the latest query used the projection
         result = project.run_sql(
             f"SELECT query, projections FROM clusterAllReplicas(default, 'system.query_log') "
             f"WHERE query like '%{unique_query_identifier}%' "
-            f"and query not like '%system.query_log%' and read_rows > 0 ORDER BY query_start_time DESC",
+            f"and query not like '%clusterAllReplicas%' and query not like '%system.query_log%' and read_rows > 0 ORDER BY query_start_time DESC",
             fetch="all",
         )
         assert len(result) > 0
@@ -191,8 +193,8 @@ class TestProjections:
         assert len(result) == 3  # We expect 3 departments in the result
         assert result == [('engineering', 43.666666666666664), ('malware', 40.0), ('sales', 25.0)]
 
-        # waiting for system.log table to be created
-        time.sleep(10)
+        # waiting for system.log table to be created/populated
+        time.sleep(SLEEP_TIME)
 
         # check that the latest query used the projection
         result = project.run_sql(

--- a/tests/integration/adapter/replicated_database/test_replicated_database.py
+++ b/tests/integration/adapter/replicated_database/test_replicated_database.py
@@ -18,9 +18,9 @@ def get_uuid_macro_value() -> str:
 
 
 @pytest.mark.skipif(
-        os.environ.get('DBT_CH_TEST_CLOUD', '').lower() in ('1', 'true', 'yes'),
-        reason='Replicated is not supported for cloud'
-    )
+    os.environ.get('DBT_CH_TEST_CLOUD', '').lower() in ('1', 'true', 'yes'),
+    reason='Replicated is not supported for cloud',
+)
 class TestReplicatedDatabaseSimpleMaterialization(BaseSimpleMaterializations):
     """Contains tests for table, view and swappable view materialization."""
 
@@ -37,7 +37,7 @@ class TestReplicatedDatabaseSimpleMaterialization(BaseSimpleMaterializations):
 
 @pytest.mark.skipif(
     os.environ.get('DBT_CH_TEST_CLOUD', '').lower() in ('1', 'true', 'yes'),
-    reason='Replicated is not supported for cloud'
+    reason='Replicated is not supported for cloud',
 )
 class TestReplicatedDatabaseIncremental(BaseIncremental):
     @pytest.fixture(scope="class")

--- a/tests/integration/adapter/replicated_database/test_replicated_database.py
+++ b/tests/integration/adapter/replicated_database/test_replicated_database.py
@@ -1,6 +1,7 @@
 import uuid
 
 import pytest
+import os
 from dbt.tests.adapter.basic.files import model_incremental, schema_base_yml
 from dbt.tests.adapter.basic.test_base import BaseSimpleMaterializations
 from dbt.tests.adapter.basic.test_incremental import BaseIncremental
@@ -16,6 +17,10 @@ def get_uuid_macro_value() -> str:
         return '{uuid}'
 
 
+@pytest.mark.skipif(
+        os.environ.get('DBT_CH_TEST_CLOUD', '').lower() in ('1', 'true', 'yes'),
+        reason='Replicated is not supported for cloud'
+    )
 class TestReplicatedDatabaseSimpleMaterialization(BaseSimpleMaterializations):
     """Contains tests for table, view and swappable view materialization."""
 
@@ -30,6 +35,10 @@ class TestReplicatedDatabaseSimpleMaterialization(BaseSimpleMaterializations):
         return test_config
 
 
+@pytest.mark.skipif(
+    os.environ.get('DBT_CH_TEST_CLOUD', '').lower() in ('1', 'true', 'yes'),
+    reason='Replicated is not supported for cloud'
+)
 class TestReplicatedDatabaseIncremental(BaseIncremental):
     @pytest.fixture(scope="class")
     def test_config(self, test_config):

--- a/tests/integration/adapter/replicated_database/test_replicated_database.py
+++ b/tests/integration/adapter/replicated_database/test_replicated_database.py
@@ -1,7 +1,8 @@
+import os
 import uuid
 
 import pytest
-import os
+
 from dbt.tests.adapter.basic.files import model_incremental, schema_base_yml
 from dbt.tests.adapter.basic.test_base import BaseSimpleMaterializations
 from dbt.tests.adapter.basic.test_incremental import BaseIncremental

--- a/tests/integration/adapter/replicated_database/test_replicated_database.py
+++ b/tests/integration/adapter/replicated_database/test_replicated_database.py
@@ -2,7 +2,6 @@ import os
 import uuid
 
 import pytest
-
 from dbt.tests.adapter.basic.files import model_incremental, schema_base_yml
 from dbt.tests.adapter.basic.test_base import BaseSimpleMaterializations
 from dbt.tests.adapter.basic.test_incremental import BaseIncremental

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -114,6 +114,15 @@ def test_config(ch_test_users, ch_test_version):
 # dbt will supply a unique schema per test, so we do not specify 'schema' here
 @pytest.fixture(scope="class")
 def dbt_profile_target(test_config):
+    custom_settings = {
+        'distributed_ddl_task_timeout': 300,
+        'input_format_skip_unknown_fields': 1,
+    }
+
+    # this setting is required for cloud tests until https://github.com/ClickHouse/ClickHouse/issues/63984 would be solved
+    if os.environ.get('DBT_CH_TEST_CLOUD', '').lower() in ('1', 'true', 'yes'):
+        custom_settings['enable_parallel_replicas'] = 0
+
     return {
         'type': 'clickhouse',
         'threads': 4,
@@ -128,10 +137,7 @@ def dbt_profile_target(test_config):
         'secure': test_config['secure'],
         'check_exchange': False,
         'use_lw_deletes': True,
-        'custom_settings': {
-            'distributed_ddl_task_timeout': 300,
-            'input_format_skip_unknown_fields': 1,
-        },
+        'custom_settings': custom_settings,
     }
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -121,7 +121,22 @@ def dbt_profile_target(test_config):
 
     # this setting is required for cloud tests until https://github.com/ClickHouse/ClickHouse/issues/63984 would be solved
     if os.environ.get('DBT_CH_TEST_CLOUD', '').lower() in ('1', 'true', 'yes'):
-        custom_settings['enable_parallel_replicas'] = 0
+        custom_settings.update({
+            'enable_parallel_replicas': 0,
+
+            # CRITICAL SETTINGS FOR CONSISTENCY
+            'mutations_sync': 3,
+            'replication_alter_partitions_sync': 2,
+            'insert_quorum': 'auto',
+
+            # DEDUPLICATION SETTINGS
+            'insert_deduplicate': 1,
+
+            # ADDITIONAL HELPFUL SETTINGS
+            'max_replica_delay_for_distributed_queries': 10,
+            'fallback_to_stale_replicas_for_distributed_queries': 0,
+            'distributed_foreground_insert': 1,
+        })
 
     return {
         'type': 'clickhouse',


### PR DESCRIPTION
## Summary

Related to https://github.com/ClickHouse/dbt-clickhouse/issues/501

A few changes related to fixing tests and fix snapshots.
* Override snapshot macro when working with timestamp strategy
* Adjust wait time for some cloud tests (for metadata to be synced before assertion)
* Skip a few replicated related tests when running on the cloud
* Fix users created by one run being removed by others.

close #493 