### PR TITLE
Always include the schema when creating a temp relation

### DIFF
--- a/dbt/include/clickhouse/macros/adapters.sql
+++ b/dbt/include/clickhouse/macros/adapters.sql
@@ -52,7 +52,7 @@
     {% if relation.schema %}
       and database = '{{ relation.schema }}'
     {% else %}
-      {% do exceptions.raise_compiler_error("Relations should always come with a defined schema. Missing schema for " ~ relation.identifier) %}
+      {% do exceptions.warn("Relations should always come with a defined schema. Missing schema for " ~ relation.identifier) %}
     {% endif %}
     order by position
   {% endcall %}

--- a/dbt/include/clickhouse/macros/adapters.sql
+++ b/dbt/include/clickhouse/macros/adapters.sql
@@ -51,6 +51,8 @@
     select name, type from system.columns where table = '{{ relation.identifier }}'
     {% if relation.schema %}
       and database = '{{ relation.schema }}'
+    {% else %}
+        {% do exceptions.raise_compiler_error("Relations should always come with a defined schema. Missing schema for " ~ relation.identifier) %}
     {% endif %}
     order by position
   {% endcall %}
@@ -81,7 +83,7 @@
 {% macro clickhouse__make_temp_relation(base_relation, suffix) %}
   {% set tmp_identifier = base_relation.identifier ~ suffix %}
   {% set tmp_relation = base_relation.incorporate(
-                              path={"identifier": tmp_identifier, "schema": None}) -%}
+                              path={"identifier": tmp_identifier, "schema": base_relation.schema}) -%}
   {% do return(tmp_relation) %}
 {% endmacro %}
 

--- a/dbt/include/clickhouse/macros/adapters.sql
+++ b/dbt/include/clickhouse/macros/adapters.sql
@@ -52,7 +52,7 @@
     {% if relation.schema %}
       and database = '{{ relation.schema }}'
     {% else %}
-        {% do exceptions.raise_compiler_error("Relations should always come with a defined schema. Missing schema for " ~ relation.identifier) %}
+      {% do exceptions.raise_compiler_error("Relations should always come with a defined schema. Missing schema for " ~ relation.identifier) %}
     {% endif %}
     order by position
   {% endcall %}


### PR DESCRIPTION
## Summary
Fixes https://github.com/ClickHouse/dbt-clickhouse/issues/510

The new temp relation wasn't including the schema. That caused some queries like the one to `system.columns` to get incorrect values.

After fixing it I cannot find more situations where this is problematic.

This also should put us closer to the parallelisation of the cloud tests.