### PR TITLE
Remove support for non-maintained CH versions. Add again support for 25.8 (latest)

### DIFF
--- a/.github/workflows/test_matrix.yml
+++ b/.github/workflows/test_matrix.yml
@@ -30,12 +30,11 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
-        clickhouse-version:
-          - '23.8'
-          - '24.3'
-          - '24.8'
+        clickhouse-version:  # Testing ClickHouse versions with active security support https://github.com/ClickHouse/ClickHouse/blob/master/SECURITY.md
           - '25.3'
-          - '25.7'  # Skipping 25.8+ until https://github.com/ClickHouse/ClickHouse/issues/86434 is fixed.
+          - '25.6'
+          - '25.7'
+          - 'latest'
 
     steps:
       - name: Checkout

--- a/tests/integration/adapter/clickhouse/test_clickhouse_table_ttl.py
+++ b/tests/integration/adapter/clickhouse/test_clickhouse_table_ttl.py
@@ -7,13 +7,7 @@ from dbt.tests.adapter.basic.files import model_base, schema_base_yml
 from dbt.tests.adapter.basic.test_base import BaseSimpleMaterializations
 from dbt.tests.util import relation_from_name, run_dbt
 
-from tests.integration.adapter.helpers import below_version
 
-
-@pytest.mark.skipif(
-    below_version(24, 3),
-    reason='Pending to fix. Syntax error in 23.8: Code: 62. DB::Exception: Syntax error: failed at position 501 (\'SETTINGS\') (line 20, col 21): SETTINGS  allow_nullable_key=1,  replicated_deduplication_window=0',
-)
 class TestTableTTL(BaseSimpleMaterializations):
     @pytest.fixture(scope="class")
     def models(self):
@@ -88,8 +82,8 @@ SELECT 3, toDateTime('2005-01-01 09:23:15')
 
 
 @pytest.mark.skipif(
-    os.environ.get('DBT_CH_TEST_CLUSTER', '').strip() == '' or below_version(24, 3),
-    reason='Not on a cluster. Also generated syntax not supported in 23.8: Code: 62. DB::Exception: Syntax error: failed at position 530 (end of query) (line 31, col 3): . Expected end of query. (SYNTAX_ERROR) (version 23.8.16.16 (official build))',
+    os.environ.get('DBT_CH_TEST_CLUSTER', '').strip() == '',
+    reason='Not on a cluster.',
 )
 class TestDistributedTableTTL:
     @pytest.fixture(scope="class")

--- a/tests/integration/adapter/materialized_view/test_materialized_view.py
+++ b/tests/integration/adapter/materialized_view/test_materialized_view.py
@@ -9,8 +9,6 @@ import pytest
 from dbt.adapters.clickhouse.query import quote_identifier
 from dbt.tests.util import check_relation_types, run_dbt
 
-from tests.integration.adapter.helpers import below_version
-
 PEOPLE_SEED_CSV = """
 id,name,age,department
 1231,Dade,33,engineering
@@ -175,10 +173,6 @@ class TestBasicMV:
         assert result[0][0] == 1
 
 
-@pytest.mark.skipif(
-    below_version(24, 3),
-    reason='Pending to fix. Syntax error in 23.8: Code: 53. DB::Exception: Cannot convert string VIEW to type UInt8: while executing...',
-)
 class TestUpdateMV:
     @pytest.fixture(scope="class")
     def seeds(self):

--- a/tests/integration/adapter/materialized_view/test_multiple_materialized_views.py
+++ b/tests/integration/adapter/materialized_view/test_multiple_materialized_views.py
@@ -9,8 +9,6 @@ import pytest
 from dbt.adapters.clickhouse.query import quote_identifier
 from dbt.tests.util import check_relation_types, run_dbt
 
-from tests.integration.adapter.helpers import below_version
-
 PEOPLE_SEED_CSV = """
 id,name,age,department
 1231,Dade,33,engineering
@@ -178,10 +176,6 @@ class TestMultipleMV:
         ]
 
 
-@pytest.mark.skipif(
-    below_version(24, 3),
-    reason='Pending to fix. Syntax error in 23.8: Code: 53. DB::Exception: Cannot convert string VIEW to type UInt8: while executing...',
-)
 class TestUpdateMultipleMV:
     @pytest.fixture(scope="class")
     def seeds(self):

--- a/tests/integration/adapter/materialized_view/test_refreshable_materialized_view.py
+++ b/tests/integration/adapter/materialized_view/test_refreshable_materialized_view.py
@@ -9,8 +9,6 @@ import os
 import pytest
 from dbt.tests.util import check_relation_types, run_dbt
 
-from tests.integration.adapter.helpers import below_version
-
 PEOPLE_SEED_CSV = """
 id,name,age,department
 1231,Dade,33,engineering
@@ -58,10 +56,6 @@ sources:
 """
 
 
-@pytest.mark.skipif(
-    below_version(25),
-    reason='Refreshable MVs are not supported in the tested 24 versions https://github.com/ClickHouse/ClickHouse/issues/59369#issuecomment-2047926705',
-)
 class TestBasicRefreshableMV:
     @pytest.fixture(scope="class")
     def seeds(self):

--- a/tests/integration/adapter/replicated_database/test_replicated_database.py
+++ b/tests/integration/adapter/replicated_database/test_replicated_database.py
@@ -1,20 +1,9 @@
 import os
-import uuid
 
 import pytest
 from dbt.tests.adapter.basic.files import model_incremental, schema_base_yml
 from dbt.tests.adapter.basic.test_base import BaseSimpleMaterializations
 from dbt.tests.adapter.basic.test_incremental import BaseIncremental
-
-from tests.integration.adapter.helpers import below_version
-
-
-def get_uuid_macro_value() -> str:
-    if below_version(25):
-        # Code: 36. DB::Exception: There was an error on [ch0:9000]: Code: 36. DB::Exception: Macro 'uuid' and empty arguments of ReplicatedMergeTree are supported only for ON CLUSTER queries with Atomic database engine. (BAD_ARGUMENTS) (version 24.3.18.7
-        return str(uuid.uuid4())
-    else:
-        return '{uuid}'
 
 
 @pytest.mark.skipif(
@@ -28,9 +17,7 @@ class TestReplicatedDatabaseSimpleMaterialization(BaseSimpleMaterializations):
     def test_config(self, test_config):
 
         test_config["db_engine"] = (
-            "Replicated('/clickhouse/databases/"
-            + get_uuid_macro_value()
-            + "', '{shard}', '{replica}')"
+            "Replicated('/clickhouse/databases/'{uuid}', '{shard}', '{replica}')"
         )
         return test_config
 
@@ -43,9 +30,7 @@ class TestReplicatedDatabaseIncremental(BaseIncremental):
     @pytest.fixture(scope="class")
     def test_config(self, test_config):
         test_config["db_engine"] = (
-            "Replicated('/clickhouse/databases/"
-            + get_uuid_macro_value()
-            + "', '{shard}', '{replica}')"
+            "Replicated('/clickhouse/databases/'{uuid}', '{shard}', '{replica}')"
         )
         return test_config
 

--- a/tests/integration/adapter/view/test_view_sql_security.py
+++ b/tests/integration/adapter/view/test_view_sql_security.py
@@ -7,8 +7,6 @@ import os
 import pytest
 from dbt.tests.util import run_dbt, run_dbt_and_capture
 
-from tests.integration.adapter.helpers import below_version
-
 PEOPLE_SEED_CSV = """
 id,name,age,department
 1231,Dade,33,engineering
@@ -92,10 +90,6 @@ class TestClickHouseViewSqlSecurity:
             "view_sql_security.sql": PEOPLE_VIEW_CONFIG_5 + PEOPLE_VIEW_MODEL,
         }
 
-    @pytest.mark.skipif(
-        below_version(24, 3),
-        reason='SQL SECURITY for views is supported in ClickHouse 24.3 and above',
-    )
     def test_create_view_invoker(self, project):
         # Load seed data
         run_dbt(["seed"])
@@ -112,10 +106,6 @@ class TestClickHouseViewSqlSecurity:
         )
         assert result[0] == 1  # 1 records in the seed data
 
-    @pytest.mark.skipif(
-        below_version(24, 3),
-        reason='SQL SECURITY for views is supported in ClickHouse 24.3 and above',
-    )
     def test_create_view_definer(self, project):
         # Load seed data
         run_dbt(["seed"])

--- a/tests/integration/test_config.xml
+++ b/tests/integration/test_config.xml
@@ -7,7 +7,7 @@
         <replica from_env="REPLICA_NUM" />
         <server_index from_env="SERVER_INDEX" />
     </macros>
-    <remote_servers>
+    <remote_servers replace="1">
         <test_shard>
             <shard>
                 <replica>


### PR DESCRIPTION


## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
