### PR TITLE
Only execute one set of tests on PRs instead of two

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,11 +3,8 @@ name: "lint"
 
 on:  # yamllint disable-line rule:truthy
   pull_request:
-  push:
-    branches-ignore:
-      - '*_test'
-      - '*_dev'
-      - '*_cloud'
+    branches: main
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/.github/workflows/test_cloud.yml
+++ b/.github/workflows/test_cloud.yml
@@ -2,9 +2,8 @@
 name: "test_cloud"
 
 on:  # yamllint disable-line rule:truthy
-  push:
-    branches:
-      - '*_cloud'
+  pull_request:
+    branches: main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_matrix.yml
+++ b/.github/workflows/test_matrix.yml
@@ -4,14 +4,6 @@ name: "test_matrix"
 on:  # yamllint disable-line rule:truthy
   pull_request:
     branches: main
-  push:
-    branches-ignore:
-      - '*_test'
-      - '*_dev'
-      - '*_cloud'
-    paths-ignore:
-      - '**.md'
-      - 'LICENSE'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
Related to https://github.com/ClickHouse/dbt-clickhouse/issues/501

All the time while working on a PR two sets of tests are being executed, everything is duplicated. With this chage:
- Only one set of test_matrix, test_cloud and lint is executed
- We still have the option to manually execute the tests in other commits with the `workflow_dispatch` keyword.