### PR TITLE
Block again cloud tests from getting executed

### DIFF
--- a/.github/workflows/test_cloud.yml
+++ b/.github/workflows/test_cloud.yml
@@ -3,7 +3,8 @@ name: "test_cloud"
 
 on:  # yamllint disable-line rule:truthy
   pull_request:
-    branches: main
+    branches:
+      - '*_cloud'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Related to https://github.com/ClickHouse/dbt-clickhouse/issues/501

I reintroduced cloud testing erroneously in https://github.com/ClickHouse/dbt-clickhouse/pull/519. Removing them again.