### PR TITLE
Fix: Improve LowCardinality validation for model contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Release [x.x.x]
 
 #### New Features
-* Allow defining columns as LowCardinality in column constraints ([xxx])
+* Allow defining columns as LowCardinality in column constraints ([#522])
 
 ### Release [1.9.3], 2025-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Release [x.x.x]
 
 #### New Features
-* Allow defining columns as LowCardinality in column constraints ([#522])
+* Allow defining columns as LowCardinality and have special types that ignore the string check in the column constraints ([#522])
 
 ### Release [1.9.3], 2025-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Release [x.x.x]
+
+#### New Features
+* Allow defining columns as LowCardinality in column constraints ([xxx])
+
 ### Release [1.9.3], 2025-09-08
 
 #### Bugs

--- a/dbt/include/clickhouse/macros/column_spec_ddl.sql
+++ b/dbt/include/clickhouse/macros/column_spec_ddl.sql
@@ -30,7 +30,16 @@
       {#-- Column with name not found in yaml #}
       {%- do exceptions.raise_contract_error(yaml_columns, sql_columns) -%}
     {%- endif -%}
-    {%- if sql_col['data_type'] != yaml_col[0]['data_type'] -%}
+
+    {%- set yaml_data_type = yaml_col[0]['data_type'] -%}
+    {%- set sql_data_type = sql_col['data_type'] -%}
+
+    {% if yaml_data_type.lower().startswith('lowcardinality') -%}
+      {#-- If contract is LowCardinality, extract the inner type for comparison --#}
+      {%- set yaml_data_type = yaml_data_type[15:-1] -%}
+    {%- endif -%}
+
+    {%- if sql_data_type != yaml_data_type -%}
       {#-- Column data types don't match #}
       {%- do exceptions.raise_contract_error(yaml_columns, sql_columns) -%}
     {%- endif -%}

--- a/dbt/include/clickhouse/macros/column_spec_ddl.sql
+++ b/dbt/include/clickhouse/macros/column_spec_ddl.sql
@@ -31,31 +31,39 @@
       {%- do exceptions.raise_contract_error(yaml_columns, sql_columns) -%}
     {%- endif -%}
 
-    {%- set yaml_data_type = yaml_col[0]['data_type'] -%}
+    {%- set ns = namespace(yaml_data_type=yaml_col[0]['data_type']) -%}
     {%- set sql_data_type = sql_col['data_type'] -%}
 
-    {%- set ns = namespace(is_special_type=false) -%}
+    {#--
+        A list of ClickHouse types where we only care about the inner type for comparison.
+        The first element is the type name (case-sensitive).
+        The second is the zero-based index of the argument to extract for comparison.
+        For example SimpleAggregateFunction(max, UInt8) has two arguments, we want to use the UInt8,
+        i.e. the second argument (index 1) for comparison.
+    --#}
+    {%- set wrapper_types = [
+        ('SimpleAggregateFunction', 1),
+        ('LowCardinality', 0)
+    ] -%}
 
-    {%- set special_types = ['SimpleAggregateFunction'] -%}
-    {%- for special_type in special_types -%}
-      {%- if yaml_data_type.startswith(special_type) -%}
-        {%- set ns.is_special_type = true -%}
-        {%- break -%}
-      {%- endif -%}
+    {%- set unwrapping = true -%}
+    {%- for _ in range(10) if unwrapping -%} {#-- Limit to 10 iterations to avoid infinite loops --#}
+      {%- set unwrapping = false -%}
+      {%- for type_name, arg_index in wrapper_types -%}
+        {%- if ns.yaml_data_type.startswith(type_name) -%}
+          {%- set ns.yaml_data_type = ns.yaml_data_type.split('(', 1)[1].rsplit(')', 1)[0] -%}
+          {%- set ns.yaml_data_type = ns.yaml_data_type.split(',')[arg_index].strip() -%}
+          {%- set unwrapping = true -%}
+          {%- break -%}
+        {%- endif -%}
+      {%- endfor -%}
     {%- endfor -%}
 
-    {% if not ns.is_special_type %}
-      {%- if yaml_data_type.startswith('LowCardinality') -%}
-        {#-- If contract is LowCardinality, extract the inner type for comparison --#}
-        {%- set yaml_data_type = yaml_data_type[15:-1] -%}
-      {%- endif -%}
-
-      {%- if sql_data_type != yaml_data_type -%}
-        {#-- Column data types don't match #}
+    {%- if sql_data_type != ns.yaml_data_type -%}
+      {#-- Column data types don't match #}
         {%- do exceptions.raise_contract_error(yaml_columns, sql_columns) -%}
       {%- endif -%}
-    {% endif %} 
-  {%- endfor -%}
+    {%- endfor -%}
 
 {% endmacro %}
 

--- a/tests/integration/adapter/constraints/fixtures_constraints.py
+++ b/tests/integration/adapter/constraints/fixtures_constraints.py
@@ -324,3 +324,28 @@ select
   'blue' as color,
   5 as country_code
 """
+
+special_types_schema_yml = """
+version: 2
+models:
+  - name: my_model
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: color
+        data_type: String
+      - name: country_code
+        data_type: SimpleAggregateFunction(any, String)
+"""
+
+special_types_schema_sql = """
+{{
+  config(
+    materialized = "table"
+  )
+}}
+select
+  'blue' as color,
+  'CH' as country_code
+"""

--- a/tests/integration/adapter/constraints/fixtures_constraints.py
+++ b/tests/integration/adapter/constraints/fixtures_constraints.py
@@ -337,6 +337,8 @@ models:
         data_type: String
       - name: country_code
         data_type: SimpleAggregateFunction(any, String)
+      - name: language_code
+        data_type: SimpleAggregateFunction(max, LowCardinality(String))
 """
 
 special_types_schema_sql = """
@@ -347,5 +349,18 @@ special_types_schema_sql = """
 }}
 select
   'blue' as color,
-  'CH' as country_code
+  'CH' as country_code,
+  'DE' as language_code
+"""
+
+special_types_schema_fail_sql = """
+{{
+  config(
+    materialized = "table"
+  )
+}}
+select
+  'blue' as color,
+  3 as country_code,
+  'DE' as language_code
 """

--- a/tests/integration/adapter/constraints/fixtures_constraints.py
+++ b/tests/integration/adapter/constraints/fixtures_constraints.py
@@ -288,3 +288,39 @@ select
   UTCtimestamp() as ts,
   'blue' as col_ttl
 """
+
+low_cardinality_schema_yml = """
+version: 2
+models:
+  - name: my_model
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: color
+        data_type: String
+      - name: country_code
+        data_type: LowCardinality(String)
+"""
+
+low_cardinality_correct_inner_type_model_sql = """
+{{
+  config(
+    materialized = "table"
+  )
+}}
+select
+  'blue' as color,
+  'CH' as country_code
+"""
+
+low_cardinality_incorrect_inner_type_model_sql = """
+{{
+  config(
+    materialized = "table"
+  )
+}}
+select
+  'blue' as color,
+  5 as country_code
+"""

--- a/tests/integration/adapter/constraints/test_constraints.py
+++ b/tests/integration/adapter/constraints/test_constraints.py
@@ -21,6 +21,8 @@ from tests.integration.adapter.constraints.fixtures_constraints import (
     low_cardinality_schema_yml,
     low_cardinality_correct_inner_type_model_sql,
     low_cardinality_incorrect_inner_type_model_sql,
+    special_types_schema_yml,
+    special_types_schema_sql,
 )
 
 
@@ -240,3 +242,14 @@ class TestIncorrectLowCardinalityConstraints:
             ["run", "-s", "my_model"], expect_pass=False
         )
         assert 'data type mismatch' in log_output.lower()
+
+class TestSpecialTypesConstraints:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "constraints_schema.yml": special_types_schema_yml,
+            "my_model.sql": special_types_schema_sql,
+        }
+
+    def test_special_type_model_constraints_ddl(self, project):
+        run_dbt(["run", "-s", "my_model"])

--- a/tests/integration/adapter/constraints/test_constraints.py
+++ b/tests/integration/adapter/constraints/test_constraints.py
@@ -209,12 +209,13 @@ class TestModelCustomConstraints:
     def test_model_constraints_ddl(self, project):
         run_dbt(["run", "-s", "check_custom_constraints_model"])
 
+
 class TestCorrectLowCardinalityConstraints:
     @pytest.fixture(scope="class")
     def models(self):
         return {
             "constraints_schema.yml": low_cardinality_schema_yml,
-            "my_model.sql": low_cardinality_correct_inner_type_model_sql
+            "my_model.sql": low_cardinality_correct_inner_type_model_sql,
         }
 
     def test_low_cardinality_contract_passes(self, project):
@@ -229,19 +230,19 @@ class TestCorrectLowCardinalityConstraints:
         assert country_code_row is not None
         assert country_code_row[1] == 'LowCardinality(String)'
 
+
 class TestIncorrectLowCardinalityConstraints:
     @pytest.fixture(scope="class")
     def models(self):
         return {
             "constraints_schema.yml": low_cardinality_schema_yml,
-            "my_model.sql": low_cardinality_incorrect_inner_type_model_sql
+            "my_model.sql": low_cardinality_incorrect_inner_type_model_sql,
         }
 
     def test_low_cardinality_contract_fails(self, project):
-        _, log_output = run_dbt_and_capture(
-            ["run", "-s", "my_model"], expect_pass=False
-        )
+        _, log_output = run_dbt_and_capture(["run", "-s", "my_model"], expect_pass=False)
         assert 'data type mismatch' in log_output.lower()
+
 
 class TestSpecialTypesConstraints:
     @pytest.fixture(scope="class")

--- a/tests/integration/adapter/constraints/test_constraints.py
+++ b/tests/integration/adapter/constraints/test_constraints.py
@@ -10,6 +10,9 @@ from tests.integration.adapter.constraints.fixtures_constraints import (
     constraint_model_schema_yml,
     contract_model_schema_yml,
     custom_constraint_model_schema_yml,
+    low_cardinality_correct_inner_type_model_sql,
+    low_cardinality_incorrect_inner_type_model_sql,
+    low_cardinality_schema_yml,
     model_data_type_schema_yml,
     my_model_data_type_sql,
     my_model_incremental_wrong_name_sql,
@@ -18,11 +21,9 @@ from tests.integration.adapter.constraints.fixtures_constraints import (
     my_model_view_wrong_order_sql,
     my_model_wrong_name_sql,
     my_model_wrong_order_sql,
-    low_cardinality_schema_yml,
-    low_cardinality_correct_inner_type_model_sql,
-    low_cardinality_incorrect_inner_type_model_sql,
-    special_types_schema_yml,
+    special_types_schema_fail_sql,
     special_types_schema_sql,
+    special_types_schema_yml,
 )
 
 
@@ -254,3 +255,28 @@ class TestSpecialTypesConstraints:
 
     def test_special_type_model_constraints_ddl(self, project):
         run_dbt(["run", "-s", "my_model"])
+
+        describe_result = project.run_sql("DESCRIBE TABLE my_model", fetch="all")
+        country_code_row = next((row for row in describe_result if row[0] == 'country_code'), None)
+        language_code_row = next(
+            (row for row in describe_result if row[0] == 'language_code'), None
+        )
+
+        assert country_code_row is not None
+        assert country_code_row[1] == 'SimpleAggregateFunction(any, String)'
+
+        assert language_code_row is not None
+        assert language_code_row[1] == 'SimpleAggregateFunction(max, LowCardinality(String))'
+
+
+class TestIncorrectSpecialTypesConstraints:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "constraints_schema.yml": special_types_schema_yml,
+            "my_model.sql": special_types_schema_fail_sql,
+        }
+
+    def test_special_type_model_constraints_fail_ddl(self, project):
+        _, log_output = run_dbt_and_capture(["run", "-s", "my_model"], expect_pass=False)
+        assert 'data type mismatch' in log_output.lower()


### PR DESCRIPTION
## Summary
This pull request resolves #303 by allowing the definition of columns as `LowCardinality` in the contracts. Before, defining a column of type `String` to be of type `LowCardinality(String)` caused an error if the constraints were enforced; otherwise, the `LowCardinality` was just ignored. 

Additionally, this PR allows defining special types that ignore the basic string comparison in the column constraints. 
At the moment, only the `SimpleAggregateFunction` is marked as a special type

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG

