### PR TITLE
ci: add `test_cloud_results.yml` placeholder workflow

### DIFF
--- a/.github/workflows/test_cloud_results.yml
+++ b/.github/workflows/test_cloud_results.yml
@@ -5,7 +5,7 @@ name: "test_cloud_results"
 on:
   workflow_dispatch:
   repository_dispatch:
-    types: [ test_cloud_results ]
+    types: [test_cloud_results]
 
 permissions:
   id-token: write

--- a/.github/workflows/test_cloud_results.yml
+++ b/.github/workflows/test_cloud_results.yml
@@ -1,0 +1,20 @@
+---
+name: "test_cloud_results"
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+  repository_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  update_commit_status:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Placeholder
+        run: echo "This is a placeholder job to trigger on repository_dispatch events."

--- a/.github/workflows/test_cloud_results.yml
+++ b/.github/workflows/test_cloud_results.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   update_commit_status:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test_cloud_results.yml
+++ b/.github/workflows/test_cloud_results.yml
@@ -5,6 +5,7 @@ name: "test_cloud_results"
 on:
   workflow_dispatch:
   repository_dispatch:
+    types: [test_cloud_results]
 
 permissions:
   id-token: write

--- a/.github/workflows/test_cloud_results.yml
+++ b/.github/workflows/test_cloud_results.yml
@@ -5,7 +5,7 @@ name: "test_cloud_results"
 on:
   workflow_dispatch:
   repository_dispatch:
-    types: [test_cloud_results]
+    types: [ test_cloud_results ]
 
 permissions:
   id-token: write
@@ -19,4 +19,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Placeholder
-        run: echo "This is a placeholder job to trigger on repository_dispatch events."
+        run: |
+          echo "This is a placeholder job to trigger on repository_dispatch events."
+
+      - name: Print event details
+        run: |
+          echo "Event Name: ${{ github.event_name }}"
+          echo "Event: ${{ github.event }}"


### PR DESCRIPTION
## Summary

This PR adds a placeholder workflow to test repository_dispatch triggers. The workflow currently does nothing; will be updated with actual logic in the follow-ups.
