### PR TITLE
Use stable version of dbt-adapters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     },
     install_requires=[
         f'dbt-core>={dbt_minor_version}',
-        'dbt-adapters==1.17.0',  # This version should be dbt-adapters>=1.17,<2.0, but keeping it fixed for now to avoid unexpected issues. We need to frequently update it.
+        'dbt-adapters>=1.16,<1.17',  # This version should be dbt-adapters>=1.16,<2.0, but keeping it fixed for now to avoid unexpected issues. We need to frequently update it.
         'clickhouse-connect>=0.6.22',
         'clickhouse-driver>=0.2.6',
         'setuptools>=0.69',


### PR DESCRIPTION
## Summary
Just realised that dbt-adapters is at 1.17.2 right now **but that is for the current, main branch version, not for the stable branch**. The stable branch is still at 1.16.7

The stable branch version is still in dbt-adapters 1.16.7:
- Stable branch https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-adapters/CHANGELOG.md
- Main branch https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-adapters/CHANGELOG.md

Changed dependency definition from 1.17.* to 1.16.*