### PR TITLE
Start testing with dbt-core 1.10

### DIFF
--- a/.github/workflows/test_cloud.yml
+++ b/.github/workflows/test_cloud.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install requirements
-        run: pip3 install -r dev_requirements.txt
+        run: pip3 install . -r dev_requirements.txt
 
       - name: Run HTTP tests
         env:

--- a/.github/workflows/test_matrix.yml
+++ b/.github/workflows/test_matrix.yml
@@ -65,7 +65,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install requirements
-        run: pip3 install -r dev_requirements.txt
+        run: pip3 install . -r dev_requirements.txt
 
       - name: Run HTTP tests
         env:

--- a/dbt/adapters/clickhouse/__version__.py
+++ b/dbt/adapters/clickhouse/__version__.py
@@ -1,1 +1,1 @@
-version = '1.9.3'
+version = '1.10.0'

--- a/dbt/adapters/clickhouse/__version__.py
+++ b/dbt/adapters/clickhouse/__version__.py
@@ -1,1 +1,1 @@
-version = '1.10.0'
+version = '1.9.3'

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,7 +1,4 @@
-dbt-core>=1.9.0,<1.10
 dbt-tests-adapter>=1.10,<2.0
-clickhouse-connect>=0.7.6
-clickhouse-driver>=0.2.7
 pytest>=7.2.0
 pytest-dotenv==0.5.2
 pytest-timeout==2.4.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ package_name = 'dbt-clickhouse'
 package_version = _dbt_clickhouse_version()
 description = '''The Clickhouse plugin for dbt (data build tool)'''
 
-dbt_minor_version = '1.9'
+dbt_minor_version = '1.10'
 
 if not package_version.startswith(dbt_minor_version):
     raise ValueError(
@@ -53,7 +53,7 @@ setup(
         ]
     },
     install_requires=[
-        f'dbt-core>={dbt_minor_version}',
+        f'dbt-core=={dbt_minor_version}.*',
         'dbt-adapters==1.17.0',  # This version should be dbt-adapters>=1.17,<2.0, but keeping it fixed for now to avoid unexpected issues. We need to frequently update it.
         'clickhouse-connect>=0.6.22',
         'clickhouse-driver>=0.2.6',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ package_name = 'dbt-clickhouse'
 package_version = _dbt_clickhouse_version()
 description = '''The Clickhouse plugin for dbt (data build tool)'''
 
-dbt_minor_version = '1.10'
+dbt_minor_version = '1.9'
 
 if not package_version.startswith(dbt_minor_version):
     raise ValueError(
@@ -53,7 +53,7 @@ setup(
         ]
     },
     install_requires=[
-        f'dbt-core=={dbt_minor_version}.*',
+        f'dbt-core>={dbt_minor_version},<1.11',
         'dbt-adapters==1.17.0',  # This version should be dbt-adapters>=1.17,<2.0, but keeping it fixed for now to avoid unexpected issues. We need to frequently update it.
         'clickhouse-connect>=0.6.22',
         'clickhouse-driver>=0.2.6',

--- a/tests/integration/adapter/concurrency/test_concurrency.py
+++ b/tests/integration/adapter/concurrency/test_concurrency.py
@@ -30,4 +30,4 @@ class TestConcurrency(BaseConcurrency):
         check_relations_equal(project.adapter, ["seed", "table_b"])
         check_table_does_not_exist(project.adapter, "invalid")
         check_table_does_not_exist(project.adapter, "skip")
-        assert "PASS=5 WARN=0 ERROR=1 SKIP=1 TOTAL=7" in output
+        assert "PASS=5 WARN=0 ERROR=1 SKIP=1 NO-OP=0 TOTAL=7" in output


### PR DESCRIPTION
## Summary

Related to https://github.com/ClickHouse/dbt-clickhouse/issues/539. You'll find the information and context about what's happening in the ticket.

This PR:
- removes the `dev` dependencies so this don't happen again
- Fixes version 1.10 of dbt-core for dbt-clickhouse 1.9 versions so at least we can make sure 1.11 is not downloaded in the future.