### PR TITLE
allow using empty local_suffix

### DIFF
--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -130,6 +130,7 @@ class ClickHouseAdapter(SQLAdapter):
             if suffix.startswith('_'):
                 return f'{suffix}'
             return f'_{suffix}'
+        return ''
 
     @available.parse(lambda *a, **k: {})
     def get_clickhouse_local_db_prefix(self):


### PR DESCRIPTION
## Summary
Allow empty local_suffix in configuration

Remove restriction that required non-empty local_suffix values.
Users can now use empty string for simpler configuration setups.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [x] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
