### PR TITLE
Fix column order in incremental materialization when using contracts

### DIFF
--- a/dbt/include/clickhouse/macros/materializations/incremental/distributed_incremental.sql
+++ b/dbt/include/clickhouse/macros/materializations/incremental/distributed_incremental.sql
@@ -27,6 +27,7 @@
   {% endif %}
   {%- set inserts_only = config.get('inserts_only') -%}
   {%- set grant_config = config.get('grants') -%}
+  {%- set has_contract = config.get('contract').enforced -%}
   {%- set full_refresh_mode = (should_full_refresh() or existing_relation.is_view) -%}
   {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}
 
@@ -57,11 +58,11 @@
 
   {% if existing_relation_local is none %}
     -- No existing local table, recreate local and distributed tables
-    {{ create_distributed_local_table(target_relation, target_relation_local, view_relation, sql) }}
+    {{ create_distributed_local_table(target_relation, target_relation_local, view_relation, sql, has_contract) }}
 
   {% elif full_refresh_mode %}
     -- Completely replacing the old table, so create a temporary table and then swap it
-    {{ create_distributed_local_table(distributed_intermediate_relation, intermediate_relation, view_relation, sql) }}
+    {{ create_distributed_local_table(distributed_intermediate_relation, intermediate_relation, view_relation, sql, has_contract) }}
     {% do adapter.drop_relation(distributed_intermediate_relation) or '' %}
     {% set need_swap = true %}
 
@@ -70,7 +71,7 @@
     -- table. It is the user's responsibility to avoid duplicates.  Note that "inserts_only" is a ClickHouse adapter
     -- specific configurable that is used to avoid creating an expensive intermediate table.
     {% call statement('main') %}
-        {{ clickhouse__insert_into(target_relation, sql) }}
+        {{ clickhouse__insert_into(target_relation, sql, has_contract) }}
     {% endcall %}
 
   {% else %}
@@ -99,7 +100,7 @@
       {% do clickhouse__incremental_insert_overwrite(existing_relation, partition_by, True) %}
     {% elif incremental_strategy == 'append' %}
       {% call statement('main') %}
-        {{ clickhouse__insert_into(target_relation, sql) }}
+        {{ clickhouse__insert_into(target_relation, sql, has_contract) }}
       {% endcall %}
     {% endif %}
   {% endif %}

--- a/dbt/include/clickhouse/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/clickhouse/macros/materializations/incremental/incremental.sql
@@ -12,6 +12,7 @@
   {% endif %}
   {%- set inserts_only = config.get('inserts_only') -%}
   {%- set grant_config = config.get('grants') -%}
+  {%- set has_contract = config.get('contract').enforced -%}
   {%- set full_refresh_mode = (should_full_refresh() or existing_relation.is_view) -%}
   {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}
 
@@ -50,7 +51,7 @@
     -- specific configurable that is used to avoid creating an expensive intermediate table.
     -- insert_overwrite strategy does not require unique_key => is an exception.
     {% call statement('main') %}
-        {{ clickhouse__insert_into(target_relation, sql) }}
+        {{ clickhouse__insert_into(target_relation, sql, has_contract) }}
     {% endcall %}
 
   {% else %}
@@ -81,7 +82,7 @@
       {% do clickhouse__incremental_delete_insert(existing_relation, unique_key, incremental_predicates) %}
     {% elif incremental_strategy == 'append' %}
       {% call statement('main') %}
-        {{ clickhouse__insert_into(target_relation, sql) }}
+        {{ clickhouse__insert_into(target_relation, sql, has_contract) }}
       {% endcall %}
     {% elif incremental_strategy == 'insert_overwrite' %}
       {% do clickhouse__incremental_insert_overwrite(existing_relation, partition_by, False) %}

--- a/tests/integration/adapter/constraints/fixtures_constraints.py
+++ b/tests/integration/adapter/constraints/fixtures_constraints.py
@@ -288,3 +288,59 @@ select
   UTCtimestamp() as ts,
   'blue' as col_ttl
 """
+
+# distributed model columns in a different order to schema definitions
+distributed_wrong_order_sql = """
+{{
+  config(
+    materialized = "distributed_table"
+  )
+}}
+
+select
+  'blue' as color,
+  1::UInt32 as id,
+  toDate('2019-01-01') as date_day
+"""
+
+# distributed model columns name different to schema definitions
+distributed_wrong_name_sql = """
+{{
+  config(
+    materialized = "distributed_table"
+  )
+}}
+
+select
+  'blue' as color,
+  1 as error,
+  '2019-01-01' as date_day
+"""
+
+distributed_incremental_wrong_order_sql = """
+{{
+  config(
+    materialized = "distributed_incremental",
+    unique_key = "id"
+  )
+}}
+
+select
+  'blue' as color,
+  1::UInt32 as id,
+  toDate('2019-01-01') as date_day
+"""
+
+distributed_incremental_wrong_name_sql = """
+{{
+  config(
+    materialized = "distributed_incremental",
+    unique_key = "id"
+  )
+}}
+
+select
+  'blue' as color,
+  1 as error,
+  '2019-01-01' as date_day
+"""


### PR DESCRIPTION
## Summary
When using [dbt contracts](https://docs.getdbt.com/reference/resource-configs/contract) on incremental models, the column order is not correctly set. This was fixed for table materializations in version 1.5.0, but was never implemented for incremental materializations.

The problem only surfaces when a different ordering is used for the columns in the contract (so in the yaml) compared to the ordering of columns in the actual user sql query. I suspect a relatively low amount of users are using all of contracts, incremental materializations and a non-consistent column order.

With this change, the `has_contract` variable is added to the incremental materializations, in a similar fashion to the table materialization. The variable is then passed through to the `insert_into` macro, which already supports correcting inconsistent column ordering by wrapping the user sql in an extra `select` statement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures column order is aligned with enforced contracts for incremental and distributed builds.
> 
> - Pass `config.get('contract').enforced` as `has_contract` through `incremental.sql`, `incremental/distributed_incremental.sql`, and `distributed_table.sql` to `clickhouse__insert_into`
> - Update `create_distributed_local_table` macro signature to accept `has_contract` and forward it during initial loads and full-refresh paths
> - Apply `has_contract` in `append`/`inserts_only` insert paths as well as table creation/swaps
> - Add integration tests for distributed table and distributed incremental contract validation; refactor shared test helpers and fixtures to include distributed variants
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c78edea0d8c5e1004dc203b14b9fda8c88bfc5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->