### PR TITLE
Prepare v1.9.7 release: Increase version and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
-### Release [1.9.7], 2025-XX-XX
+### Release [1.9.7], 2025-12-03
 
 #### New Features
 * Add `clickhouse__safe_cast` macro that automatically provides default values for ClickHouse types when casting null values. This eliminates the need to specify all non-nullable columns in unit test fixtures ([#552](https://github.com/ClickHouse/dbt-clickhouse/pull/552)).
 
 #### Improvements
-* Change tests to use dbt-core 1.10 to start validating new functionality ([#570](https://github.com/ClickHouse/dbt-clickhouse/pull/570)).
-* Validate that the new `--sample` flag ([docs](https://docs.getdbt.com/docs/build/sample-flag)) works. Add tests to cover the implementation ([#570](https://github.com/ClickHouse/dbt-clickhouse/pull/570)).
+* We are now officially supporting dbt-core 1.10!
+  * Validate that the new `--sample` flag ([docs](https://docs.getdbt.com/docs/build/sample-flag)) works. Add tests to cover the implementation ([#570](https://github.com/ClickHouse/dbt-clickhouse/pull/570)).
+  * We have validated that the code doesn't raise warnings related to deprecations for future dbt versions
+  * Change tests to use dbt-core 1.10 to start validating new functionality ([#570](https://github.com/ClickHouse/dbt-clickhouse/pull/570)).
+  * dbt Catalogs feature is not supported right now, but workarounds are going to be documented.
 
 
 ### Release [1.9.6], 2025-11-03

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ pip install dbt-clickhouse
 - [x] Distributed table materialization (experimental)
 - [x] Distributed incremental materialization (experimental)
 - [x] Contracts
+- [x] ClickHouse-specific column configurations (Codec, TTL...)
+- [x] ClickHouse-specific table settings (indexes, projections...)
+
+All features up to dbt-core 1.10 are supported, including `--sample` flag and all deprecation warnings fixed for future releases. **Catalog integrations** (e.g., Iceberg) introduced in dbt 1.10 are not yet natively supported in the adapter, but workarounds are available. See the [Catalog Support section](/integrations/dbt/features-and-configurations#catalog-support) for details.
+
+This adapter is still not available for use inside [dbt Cloud](https://docs.getdbt.com/docs/dbt-cloud/cloud-overview), but we expect to make it available soon. Please reach out to support to get more information on this.
 
 ## Contributing
 

--- a/dbt/adapters/clickhouse/__version__.py
+++ b/dbt/adapters/clickhouse/__version__.py
@@ -1,1 +1,1 @@
-version = '1.9.6'
+version = '1.9.7'


### PR DESCRIPTION
## Summary
- Prepare v1.9.7 release: Increase version and update changelog

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
