### PR TITLE
docs: Add compatibility matrix to README (#565)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Release [1.9.9], 2026-XX-XX
 
+#### Documentation
+* Add compatibility matrix to README to help users understand version requirements ([#565](https://github.com/ClickHouse/dbt-clickhouse/issues/565)).
 
 ### Release [1.9.8], 2026-01-12
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ pip install dbt-clickhouse
 - [x] ClickHouse-specific column configurations (Codec, TTL...)
 - [x] ClickHouse-specific table settings (indexes, projections...)
 
+## Compatibility Matrix
+
+| dbt-clickhouse | dbt-core | Python     | ClickHouse | clickhouse-connect |
+|----------------|----------|------------|------------|-------------------|
+| 1.9.x          | ≥1.9     | 3.10-3.13  | 24.8+      | ≥0.10.0           |
+| 1.8.x          | ≥1.8     | 3.9-3.12   | 23.8+      | ≥0.8.0            |
+| 1.7.x          | ≥1.7     | 3.8-3.11   | 22.8+      | ≥0.6.0            |
+
+> **Note:** ClickHouse versions listed are the minimum tested versions. Newer versions are generally supported.
+> Python 3.9 support was dropped in dbt-clickhouse 1.9.8.
+
 All features up to dbt-core 1.10 are supported, including `--sample` flag and all deprecation warnings fixed for future releases. **Catalog integrations** (e.g., Iceberg) introduced in dbt 1.10 are not yet natively supported in the adapter, but workarounds are available. See the [Catalog Support section](/integrations/dbt/features-and-configurations#catalog-support) for details.
 
 This adapter is still not available for use inside [dbt Cloud](https://docs.getdbt.com/docs/dbt-cloud/cloud-overview), but we expect to make it available soon. Please reach out to support to get more information on this.


### PR DESCRIPTION
Add a compatibility matrix table to README.md showing version compatibility for dbt-clickhouse, dbt-core, Python, ClickHouse, and clickhouse-connect. This helps users understand version requirements at a glance.

Closes #565

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a **Compatibility Matrix** in `README.md` detailing supported versions across `dbt-clickhouse`, `dbt-core`, Python, ClickHouse, and `clickhouse-connect`.
> 
> - New `README` section summarizes minimum tested ClickHouse versions and notes Python 3.9 support dropped in `1.9.8`
> - Updates `CHANGELOG.md` (Release `1.9.9` → Documentation) to reference this addition (#565)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1c6f85c204a35a4e8ee8e4956a3f7c809aad8be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->