### PR TITLE
fix: add ON CLUSTER for incremental models when cluster is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Release [1.9.9], 2026-XX-XX
 
+#### Bugs
+* Fix incremental models failing with `ON CLUSTER` when the table exists on a single shard. The `can_on_cluster` flag now also considers the cluster configuration from the profile, not just the actual shard distribution ([#273](https://github.com/ClickHouse/dbt-clickhouse/issues/273)).
+
 
 ### Release [1.9.8], 2026-01-12
 

--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -341,6 +341,8 @@ class ClickHouseAdapter(SQLAdapter):
         results = self.execute_macro('list_relations_without_caching', kwargs=kwargs)
         conn_supports_exchange = self.supports_atomic_exchange()
 
+        cluster_configured = bool(self.get_clickhouse_cluster_name())
+
         relations = []
         for row in results:
             name, schema, type_info, db_engine, on_cluster = row
@@ -355,7 +357,7 @@ class ClickHouseAdapter(SQLAdapter):
                 and rel_type == ClickHouseRelationType.Table
                 and engine_can_atomic_exchange(db_engine)
             )
-            can_on_cluster = (on_cluster >= 1) and db_engine != 'Replicated'
+            can_on_cluster = (cluster_configured or on_cluster >= 1) and db_engine != 'Replicated'
 
             relation = self.Relation.create(
                 database='',


### PR DESCRIPTION
Fixes #273 - Incremental models with `ON CLUSTER` now work correctly on subsequent runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes ON CLUSTER handling for incremental models when a cluster is configured but tables reside on a single shard.
> 
> - Update `list_relations_without_caching` to set `can_on_cluster` if a profile-level cluster is configured (or detected in metadata) and engine is not `Replicated`
> - Add bug note to `CHANGELOG.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2213e56087d94b9ac42fe67333dc0b4822261cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->