### PR TITLE
Update dbt-adapters version to 1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Respect `catchup` configuration flag during full refresh operations for materialized views. When `catchup: False` is set, the target table will not be backfilled with historical data during full refresh, providing consistent behavior across initial creation and redeployment scenarios ([#589](https://github.com/ClickHouse/dbt-clickhouse/pull/589)).
 * Add update_field and update_lag, which is used in https://clickhouse.com/docs/sql-reference/dictionaries#refreshing-dictionary-data-using-lifetime and makes lifetime optional ([#580](https://github.com/ClickHouse/dbt-clickhouse/pull/580)).
 * Move to declarative packaging to provide better tooling integration and build isolation (by enabling python-build) ([#593](https://github.com/ClickHouse/dbt-clickhouse/issues/593)).
+* Update `dbt-adapters` version to 1.22 ([#609](https://github.com/ClickHouse/dbt-clickhouse/issues/609)).
 
 #### Bugs
 * Fix incremental models failing with `ON CLUSTER` when the table exists on a single shard. The `can_on_cluster` flag now also considers the cluster configuration from the profile, not just the actual shard distribution ([#273](https://github.com/ClickHouse/dbt-clickhouse/issues/273)).

--- a/dbt/include/clickhouse/macros/materializations/unit.sql
+++ b/dbt/include/clickhouse/macros/materializations/unit.sql
@@ -24,7 +24,7 @@
   {%- endfor -%}
 
   {% if not expected_sql %}
-  {%   set expected_sql = get_expected_sql(expected_rows, column_name_to_data_types) %}
+  {%   set expected_sql = get_expected_sql(expected_rows, column_name_to_data_types, column_name_to_quoted) %}
   {% endif %}
   {% set unit_test_sql = get_unit_test_sql(sql, expected_sql, expected_column_names_quoted) %}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "dbt-core>=1.9",
-    "dbt-adapters>=1.16.7,<1.17",
+    "dbt-adapters>=1.22.0,<1.22.6",  # This version should be dbt-adapters<2.0, but keeping it fixed for now to avoid unexpected issues. We need to frequently update it.
     "clickhouse-connect>=0.10.0",
     "clickhouse-driver>=0.2.10"
 ]


### PR DESCRIPTION
## Summary
Closes https://github.com/ClickHouse/dbt-clickhouse/issues/604
Also needed for https://github.com/ClickHouse/dbt-clickhouse/pull/588


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency upgrade may introduce behavior changes from `dbt-adapters` 1.22 that affect runtime/test integration. The macro change is small but impacts unit-test SQL generation and could surface quoting-related regressions.
> 
> **Overview**
> **Bumps the adapter framework dependency** by updating `dbt-adapters` from the previous `1.16.x` pin to `>=1.22.0,<1.22.6`, and documents the upgrade in the `1.9.9` changelog.
> 
> Also updates the unit-test materialization to pass quoted column identifiers into `get_expected_sql`, improving expected-SQL generation for unit tests when columns require quoting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da9b80e48fe64bb28eb9aa6030fc02d47e573fbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->