### PR TITLE
Prepare v1.10.0 release: Increase version and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,22 @@
-### Release [1.9.9], 2026-XX-XX
+### Release [1.10.0], 2026-02-16
+
+This is an interesting release with many changes! Please take some time to review the notes before upgrading it. All changes are expected to be backward compatible, but some of them may require adjustments in your code.
+
+#### Changes that specially require your attention
+* Respect `catchup` in `materializataion: materialized_view` configuration flag during full refresh operations for materialized views. When `catchup: False` is set, the target table will not be backfilled with historical data during full refresh, providing consistent behavior across initial creation and redeployment scenarios ([#589](https://github.com/ClickHouse/dbt-clickhouse/pull/589)).
+* Add `select_sequential_consistency=1` setting for SharedMergeTree (`database_engine: Shared`) to ensure read-after-write consistency. Shared engine also uses stricter `mutations_sync=3` and `alter_sync=3` defaults. All connection settings now use `setdefault()` allowing users to override defaults via `custom_settings`. Those settings are expected to be safe for all dbt workloads so it's safe in production, but in specific performance critical situations you may want to override it ([#596](https://github.com/ClickHouse/dbt-clickhouse/issues/596)).
 
 #### Improvements
-* Huge new update for Materialized Views! Now you can define which target table will be used. For a full context on how to use it, check the [documentation](hthttps://clickhouse.com/docs/integrations/dbt) ([#582](https://github.com/ClickHouse/dbt-clickhouse/issues/582))..
-* Respect `catchup` configuration flag during full refresh operations for materialized views. When `catchup: False` is set, the target table will not be backfilled with historical data during full refresh, providing consistent behavior across initial creation and redeployment scenarios ([#589](https://github.com/ClickHouse/dbt-clickhouse/pull/589)).
-* Add update_field and update_lag, which is used in https://clickhouse.com/docs/sql-reference/dictionaries#refreshing-dictionary-data-using-lifetime and makes lifetime optional ([#580](https://github.com/ClickHouse/dbt-clickhouse/pull/580)).
-* Add `select_sequential_consistency` setting for SharedMergeTree (`database_engine: Shared`) to ensure read-after-write consistency. Shared engine also uses stricter `mutations_sync=3` and `alter_sync=3` defaults. All connection settings now use `setdefault()` allowing users to override defaults via `custom_settings` ([#596](https://github.com/ClickHouse/dbt-clickhouse/issues/596)).
+* Huge new update for Materialized Views! Now you can define which target table will be used. For a full context on how to use it, check the [documentation](https://clickhouse.com/docs/integrations/dbt/materialization-materialized-view) ([#582](https://github.com/ClickHouse/dbt-clickhouse/issues/582)).
+* Add in `materializataion: dictionary` the settings update_field and update_lag, which is used in https://clickhouse.com/docs/sql-reference/dictionaries#refreshing-dictionary-data-using-lifetime and make lifetime optional ([#580](https://github.com/ClickHouse/dbt-clickhouse/pull/580)).
 * Move to declarative packaging to provide better tooling integration and build isolation (by enabling python-build) ([#593](https://github.com/ClickHouse/dbt-clickhouse/issues/593)).
 * Update `dbt-adapters` version to 1.22 ([#609](https://github.com/ClickHouse/dbt-clickhouse/issues/609)).
 
 #### Bugs
 * Fix incremental models failing with `ON CLUSTER` when the table exists on a single shard. The `can_on_cluster` flag now also considers the cluster configuration from the profile, not just the actual shard distribution ([#273](https://github.com/ClickHouse/dbt-clickhouse/issues/273)).
-* Fix issue where AWS credentials (`aws_access_key_id` and `aws_secret_access_key`) were not being read when defined outside the macro call ([#601](https://github.com/ClickHouse/dbt-clickhouse/issues/601)).
-* Fix the same AWS credentials issue, but with the `role_arn` parameter ([#440](https://github.com/ClickHouse/dbt-clickhouse/issues/440)).
+* Fix issue where AWS credentials used in `s3source` were not read when defined outside the macro call:
+  * Fix for `aws_access_key_id` and `aws_secret_access_key` ([#601](https://github.com/ClickHouse/dbt-clickhouse/issues/601)).
+  * Fix for `role_arn` ([#440](https://github.com/ClickHouse/dbt-clickhouse/issues/440)).
 
 
 ### Release [1.9.8], 2026-01-12

--- a/dbt/adapters/clickhouse/__version__.py
+++ b/dbt/adapters/clickhouse/__version__.py
@@ -1,1 +1,1 @@
-version = '1.9.8'
+version = '1.10.0'


### PR DESCRIPTION
## Summary
Prepare next release

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release bookkeeping only (version string and changelog text), with no runtime code changes.
> 
> **Overview**
> Prepares the `1.10.0` release by bumping the adapter version from `1.9.8` to `1.10.0`.
> 
> Updates `CHANGELOG.md` with finalized `1.10.0` release notes (date, highlighted upgrade-attention items, corrected docs link, and consolidated AWS `s3source` credential fix entries).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 320cd17aa773f9e09d0d834e54eb4957a9b2f976. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->