### PR TITLE
Use trusted publisher to publish packages

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -14,6 +14,10 @@ jobs:
     name: PyPI Release
     runs-on: ubuntu-latest
 
+    permissions:
+      # IMPORTANT: this permission is mandatory for Trusted Publishing
+      id-token: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,6 +35,3 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Release [1.10.1], 2026-0X-XX
+
+#### Improvements
+* Starting with this release the `dbt-clickhouse` packages will be published to PyPI using Github Actions as a [Trusted Publisher](https://docs.pypi.org/trusted-publishers/). This will improve both the usability and the security of the release process ([#614](https://github.com/ClickHouse/dbt-clickhouse/pull/614)).
+
+
 ### Release [1.10.0], 2026-02-16
 
 This is an interesting release with many changes! Please take some time to review the notes before upgrading it. All changes are expected to be backward compatible, but some of them may require adjustments in your code.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ Repository = "https://github.com/ClickHouse/dbt-clickhouse"
 Issues = "https://github.com/ClickHouse/dbt-clickhouse/issues"
 Documentation = "https://github.com/ClickHouse/dbt-clickhouse#documentation"
 Changelog = "https://github.com/ClickHouse/dbt-clickhouse/blob/main/CHANGELOG.md"
-slack = "https://clickhouse.com/slack"
+Slack = "https://clickhouse.com/slack"
 
 [tool.setuptools]
 packages = {find = {include = ["dbt", "dbt.*"], namespaces = true}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dependencies = [
 Homepage = "https://github.com/ClickHouse/dbt-clickhouse"
 Repository = "https://github.com/ClickHouse/dbt-clickhouse"
 Issues = "https://github.com/ClickHouse/dbt-clickhouse/issues"
+Documentation = "https://github.com/ClickHouse/dbt-clickhouse#documentation"
+Changelog = "https://github.com/ClickHouse/dbt-clickhouse/blob/main/CHANGELOG.md"
+slack = "https://clickhouse.com/slack"
 
 [tool.setuptools]
 packages = {find = {include = ["dbt", "dbt.*"], namespaces = true}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ Homepage = "https://github.com/ClickHouse/dbt-clickhouse"
 Repository = "https://github.com/ClickHouse/dbt-clickhouse"
 Issues = "https://github.com/ClickHouse/dbt-clickhouse/issues"
 Documentation = "https://github.com/ClickHouse/dbt-clickhouse#documentation"
+"ClickHouse Docs" = "https://clickhouse.com/docs/integrations/dbt"
 Changelog = "https://github.com/ClickHouse/dbt-clickhouse/blob/main/CHANGELOG.md"
 Slack = "https://clickhouse.com/slack"
 


### PR DESCRIPTION
## Summary
Closes #592 

With these changes, next time we release a version it will be done using the Trusted Publisher workflow.

We have already configured it in PyPI.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release automation changes only; main risk is misconfigured GitHub/PyPI OIDC permissions causing publish failures, not runtime/user-facing behavior.
> 
> **Overview**
> Switches the PyPI release GitHub Actions workflow to **PyPI Trusted Publishing** by granting `id-token: write` and removing the token/password secret-based publish configuration.
> 
> Updates metadata/docs to reflect the new release process: adds a `1.10.1` changelog entry about trusted publishing and expands `pyproject.toml` `project.urls` with documentation, changelog, and community links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eea43a27029cf46705f52f1bc0fb0858d62b25bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->