### PR TITLE
feat: populate query_id in AdapterResponse from ClickHouse driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Release [1.10.1], 2026-0X-XX
 
 #### Improvements
+* Populate `query_id` in `AdapterResponse` from the ClickHouse driver result. The HTTP client exposes `query_id` via `QueryResult.query_id` (fetch queries) and `QuerySummary.summary['query_id']` (command queries). This enables users to correlate dbt model executions with `system.query_log` for debugging, resource tracking, and query profiling ([#617](https://github.com/ClickHouse/dbt-clickhouse/issues/617)).
 * Starting with this release the `dbt-clickhouse` packages will be published to PyPI using Github Actions as a [Trusted Publisher](https://docs.pypi.org/trusted-publishers/). This will improve both the usability and the security of the release process ([#614](https://github.com/ClickHouse/dbt-clickhouse/pull/614)).
 
 

--- a/dbt/adapters/clickhouse/connections.py
+++ b/dbt/adapters/clickhouse/connections.py
@@ -103,7 +103,16 @@ class ClickHouseConnectionManager(SQLConnectionManager):
                 from dbt_common.clients.agate_helper import empty_table
 
                 table = empty_table()
-            return AdapterResponse(_message=status), table
+
+            query_id = ''
+            if fetch and hasattr(query_result, 'query_id'):
+                query_id = query_result.query_id or ''
+            elif not fetch and hasattr(query_result, 'summary') and isinstance(
+                query_result.summary, dict
+            ):
+                query_id = query_result.summary.get('query_id', '')
+
+            return AdapterResponse(_message=status, query_id=query_id), table
 
     def add_query(
         self,

--- a/dbt/adapters/clickhouse/connections.py
+++ b/dbt/adapters/clickhouse/connections.py
@@ -107,8 +107,10 @@ class ClickHouseConnectionManager(SQLConnectionManager):
             query_id = ''
             if fetch and hasattr(query_result, 'query_id'):
                 query_id = query_result.query_id or ''
-            elif not fetch and hasattr(query_result, 'summary') and isinstance(
-                query_result.summary, dict
+            elif (
+                not fetch
+                and hasattr(query_result, 'summary')
+                and isinstance(query_result.summary, dict)
             ):
                 query_id = query_result.summary.get('query_id', '')
 

--- a/tests/unit/test_query_id.py
+++ b/tests/unit/test_query_id.py
@@ -1,0 +1,91 @@
+from unittest.mock import MagicMock, patch
+
+from dbt.adapters.clickhouse.connections import ClickHouseConnectionManager
+
+
+def _make_manager():
+    """Return a ClickHouseConnectionManager with a mocked thread connection."""
+    manager = ClickHouseConnectionManager.__new__(ClickHouseConnectionManager)
+    return manager
+
+
+def _mock_connection(query_result):
+    """Build a fake thread connection whose handle returns query_result."""
+    client = MagicMock()
+    client.query.return_value = query_result
+    client.command.return_value = query_result
+
+    conn = MagicMock()
+    conn.handle = client
+
+    return conn
+
+
+def test_execute_fetch_populates_query_id():
+    """HTTP client: fetch=True reads query_id from QueryResult.query_id."""
+    query_result = MagicMock()
+    query_result.query_id = 'abc-123'
+    query_result.result_set = []
+    query_result.column_names = []
+
+    manager = _make_manager()
+    conn = _mock_connection(query_result)
+
+    with (
+        patch.object(manager, 'get_thread_connection', return_value=conn),
+        patch.object(manager, '_add_query_comment', side_effect=lambda sql: sql),
+    ):
+        response, _ = manager.execute('SELECT 1', fetch=True)
+
+    assert response.query_id == 'abc-123'
+
+
+def test_execute_command_populates_query_id():
+    """HTTP client: fetch=False reads query_id from QuerySummary.summary dict."""
+    query_result = MagicMock()
+    query_result.summary = {'query_id': 'def-456', 'read_rows': '1'}
+
+    manager = _make_manager()
+    conn = _mock_connection(query_result)
+
+    with (
+        patch.object(manager, 'get_thread_connection', return_value=conn),
+        patch.object(manager, '_add_query_comment', side_effect=lambda sql: sql),
+    ):
+        response, _ = manager.execute('CREATE TABLE t (x Int32) ENGINE=Memory', fetch=False)
+
+    assert response.query_id == 'def-456'
+
+
+def test_execute_native_client_fetch_returns_empty_query_id():
+    """Native client: no query_id attribute on result — query_id falls back to ''."""
+    query_result = MagicMock(spec=[])  # no attributes at all
+    query_result.result_set = []
+    query_result.column_names = []
+
+    manager = _make_manager()
+    conn = _mock_connection(query_result)
+
+    with (
+        patch.object(manager, 'get_thread_connection', return_value=conn),
+        patch.object(manager, '_add_query_comment', side_effect=lambda sql: sql),
+    ):
+        response, _ = manager.execute('SELECT 1', fetch=True)
+
+    assert response.query_id == ''
+
+
+def test_execute_native_client_command_returns_empty_query_id():
+    """Native client: no summary dict on result — query_id falls back to ''."""
+    query_result = MagicMock(spec=[])  # no attributes at all
+
+    manager = _make_manager()
+    conn = _mock_connection(query_result)
+
+    with (
+        patch.object(manager, 'get_thread_connection', return_value=conn),
+        patch.object(manager, '_add_query_comment', side_effect=lambda sql: sql),
+    ):
+        response, _ = manager.execute('DROP TABLE IF EXISTS t', fetch=False)
+
+    assert response.query_id == ''


### PR DESCRIPTION
## Summary

Closes #617

The `execute()` method in `connections.py` now extracts `query_id` from the ClickHouse driver result and passes it through to `AdapterResponse`.

### How it works

The dbt-core `AdapterResponse` dataclass already has a `query_id` field but it was never populated. The fix uses `hasattr` checks to handle both client types gracefully:

- **HTTP client (clickhouse-connect), `fetch=True`**: reads `QueryResult.query_id`
- **HTTP client (clickhouse-connect), `fetch=False`**: reads `QuerySummary.summary['query_id']`
- **Native client (clickhouse-driver)**: `query_id` is not exposed by the driver — gracefully falls back to empty string

No new imports are required. The checks are non-breaking for both client types.

### Changes

- `dbt/adapters/clickhouse/connections.py`: extract and pass `query_id` in `execute()`
- `CHANGELOG.md`: add entry under upcoming `1.10.1` release

### Why this matters

Without `query_id` in the adapter response, users must rely on fragile timestamp-based correlation with `system.query_log`. With this change, dbt model executions can be directly correlated with ClickHouse's query log for debugging slow runs, tracking memory/CPU usage per model, and linking dbt results to ClickHouse query profiling data.