### PR TITLE
feat: populate query_id in AdapterResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Improvements
 * Starting with this release the `dbt-clickhouse` packages will be published to PyPI using Github Actions as a [Trusted Publisher](https://docs.pypi.org/trusted-publishers/). This will improve both the usability and the security of the release process ([#614](https://github.com/ClickHouse/dbt-clickhouse/pull/614)).
+* Populate `query_id` in `AdapterResponse` for every executed query. The query ID is generated as a UUID4 and forwarded to ClickHouse, making it available via `adapter_response` in dbt artifacts and enabling tools like Elementary to correlate dbt model runs with entries in `system.query_log`.
 
 
 ### Release [1.10.0], 2026-02-16

--- a/dbt/adapters/clickhouse/connections.py
+++ b/dbt/adapters/clickhouse/connections.py
@@ -1,5 +1,6 @@
 import re
 import time
+import uuid
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Optional, Tuple, Union
 
@@ -86,13 +87,14 @@ class ClickHouseConnectionManager(SQLConnectionManager):
         conn = self.get_thread_connection()
         client = conn.handle
 
+        query_id = str(uuid.uuid4())
         with self.exception_handler(sql):
             logger.debug(f'On {conn.name}: {sql}...')
             pre = time.time()
             if fetch:
-                query_result = client.query(sql)
+                query_result = client.query(sql, query_id=query_id)
             else:
-                query_result = client.command(sql)
+                query_result = client.command(sql, query_id=query_id)
             status = self.get_status(client)
             logger.debug(f'SQL status: {status} in {(time.time() - pre):.2f} seconds')
             if fetch:
@@ -103,7 +105,7 @@ class ClickHouseConnectionManager(SQLConnectionManager):
                 from dbt_common.clients.agate_helper import empty_table
 
                 table = empty_table()
-            return AdapterResponse(_message=status), table
+            return AdapterResponse(_message=status, query_id=query_id), table
 
     def add_query(
         self,

--- a/dbt/adapters/clickhouse/httpclient.py
+++ b/dbt/adapters/clickhouse/httpclient.py
@@ -11,8 +11,15 @@ from dbt_common.exceptions import DbtDatabaseError
 
 
 class ChHttpClient(ChClientWrapper):
+    @staticmethod
+    def _inject_query_id(kwargs):
+        query_id = kwargs.pop('query_id', None)
+        if query_id:
+            kwargs.setdefault('settings', {})['query_id'] = query_id
+
     def query(self, sql, **kwargs):
         try:
+            self._inject_query_id(kwargs)
             return self._client.query(sql, **kwargs)
         except DatabaseError as ex:
             err_msg = hide_stack_trace(ex)
@@ -20,6 +27,7 @@ class ChHttpClient(ChClientWrapper):
 
     def command(self, sql, **kwargs):
         try:
+            self._inject_query_id(kwargs)
             return self._client.command(sql, **kwargs)
         except DatabaseError as ex:
             err_msg = hide_stack_trace(ex)

--- a/tests/integration/adapter/clickhouse/test_adapter_response.py
+++ b/tests/integration/adapter/clickhouse/test_adapter_response.py
@@ -1,0 +1,32 @@
+import pytest
+from clickhouse_connect import get_client
+from dbt.tests.util import run_dbt
+
+model_sql = """
+select 1 as id, 'clickhouse' as name
+"""
+
+
+class TestAdapterResponseQueryId:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"my_model.sql": model_sql}
+
+    def test_query_id_round_trips_to_query_log(self, project, test_config):
+        results = run_dbt(["run"])
+        assert len(results.results) == 1
+
+        query_id = results.results[0].adapter_response.get("query_id")
+        assert query_id, "adapter_response did not contain a query_id"
+
+        ch = get_client(
+            host=test_config["host"],
+            port=test_config.get("client_port", 8123),
+            username=test_config["user"],
+            password=test_config["password"],
+            secure=test_config["secure"],
+        )
+        ch.command("SYSTEM FLUSH LOGS")
+
+        count = ch.command(f"SELECT count() FROM system.query_log WHERE query_id = '{query_id}'")
+        assert count > 0, f"query_id {query_id!r} not found in system.query_log"

--- a/tests/integration/adapter/clickhouse/test_adapter_response.py
+++ b/tests/integration/adapter/clickhouse/test_adapter_response.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from clickhouse_connect import get_client
 from dbt.tests.util import run_dbt
@@ -19,14 +21,19 @@ class TestAdapterResponseQueryId:
         query_id = results.results[0].adapter_response.get("query_id")
         assert query_id, "adapter_response did not contain a query_id"
 
-        ch = get_client(
-            host=test_config["host"],
-            port=test_config.get("client_port", 8123),
-            username=test_config["user"],
-            password=test_config["password"],
-            secure=test_config["secure"],
-        )
-        ch.command("SYSTEM FLUSH LOGS")
+        on_cloud = os.environ.get('DBT_CH_TEST_CLOUD', default='').lower() in ('1', 'true', 'yes')
+        cluster = os.environ.get('DBT_CH_TEST_CLUSTER', '').strip()
+        cluster = 'default' if not cluster and on_cloud else cluster
 
-        count = ch.command(f"SELECT count() FROM system.query_log WHERE query_id = '{query_id}'")
-        assert count > 0, f"query_id {query_id!r} not found in system.query_log"
+        cluster_clause = f'ON CLUSTER "{cluster}"' if cluster else ''
+        project.run_sql(f"SYSTEM FLUSH LOGS {cluster_clause}", fetch="all")
+
+        from_clause = (
+            f"FROM clusterAllReplicas('{cluster}', system.query_log)"
+            if on_cloud
+            else "FROM system.query_log"
+        )
+        count = project.run_sql(
+            f"SELECT count() {from_clause} WHERE query_id = '{query_id}'", fetch="one"
+        )
+        assert count[0] > 0, f"query_id {query_id!r} not found in system.query_log"

--- a/tests/unit/test_connections.py
+++ b/tests/unit/test_connections.py
@@ -1,0 +1,59 @@
+import uuid
+from unittest.mock import MagicMock, patch
+
+from dbt.adapters.clickhouse.connections import ClickHouseConnectionManager
+
+
+def _make_manager_with_client(mock_client):
+    conn = MagicMock()
+    conn.name = 'test'
+    conn.handle = mock_client
+
+    manager = ClickHouseConnectionManager.__new__(ClickHouseConnectionManager)
+    manager.get_thread_connection = MagicMock(return_value=conn)
+    manager._add_query_comment = lambda s: s
+    return manager
+
+
+class TestAdapterResponseQueryId:
+    def test_query_id_passed_to_client_on_fetch(self):
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.result_set = [('val',)]
+        mock_result.column_names = ['col']
+        mock_client.query.return_value = mock_result
+
+        response, _ = _make_manager_with_client(mock_client).execute('SELECT 1', fetch=True)
+
+        _, kwargs = mock_client.query.call_args
+        assert 'query_id' in kwargs
+        assert kwargs['query_id'] == response.query_id
+
+    def test_query_id_passed_to_client_on_command(self):
+        mock_client = MagicMock()
+        mock_client.command.return_value = None
+
+        response, _ = _make_manager_with_client(mock_client).execute('CREATE TABLE t (x Int32) ENGINE=Memory')
+
+        _, kwargs = mock_client.command.call_args
+        assert 'query_id' in kwargs
+        assert kwargs['query_id'] == response.query_id
+
+    def test_query_id_is_valid_uuid(self):
+        mock_client = MagicMock()
+        mock_client.command.return_value = None
+
+        response, _ = _make_manager_with_client(mock_client).execute('SELECT 1')
+
+        # raises ValueError if not a valid UUID
+        uuid.UUID(response.query_id)
+
+    def test_query_id_unique_per_call(self):
+        mock_client = MagicMock()
+        mock_client.command.return_value = None
+
+        manager = _make_manager_with_client(mock_client)
+        r1, _ = manager.execute('SELECT 1')
+        r2, _ = manager.execute('SELECT 1')
+
+        assert r1.query_id != r2.query_id

--- a/tests/unit/test_connections.py
+++ b/tests/unit/test_connections.py
@@ -33,7 +33,9 @@ class TestAdapterResponseQueryId:
         mock_client = MagicMock()
         mock_client.command.return_value = None
 
-        response, _ = _make_manager_with_client(mock_client).execute('CREATE TABLE t (x Int32) ENGINE=Memory')
+        response, _ = _make_manager_with_client(mock_client).execute(
+            'CREATE TABLE t (x Int32) ENGINE=Memory'
+        )
 
         _, kwargs = mock_client.command.call_args
         assert 'query_id' in kwargs


### PR DESCRIPTION
## Summary

Populate `query_id` in `AdapterResponse` for every query executed by the adapter.

A UUID4 is generated before each query and forwarded to ClickHouse, so the same ID appears in both the dbt `adapter_response` and `system.query_log`. This enables observability tools like [Elementary](https://github.com/elementary-data/dbt-data-reliability) to correlate dbt model runs with ClickHouse query history — functionality that was previously only available for the Snowflake adapter ([elementary-data/dbt-data-reliability#146](https://github.com/elementary-data/dbt-data-reliability/pull/146)).

**Implementation notes:**
- `connections.py`: generates a UUID4 per `execute()` call, passes it to the client, and sets `AdapterResponse.query_id`
- `httpclient.py`: translates `query_id` from kwargs into `settings` (URL parameter), since `clickhouse-connect`'s `query()` and `command()` don't accept it directly — it must travel as a ClickHouse query parameter
- `nativeclient.py`: unchanged — `clickhouse-driver`'s `execute()` already accepts `query_id` natively via kwargs

## Checklist

- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
