### PR TITLE
Test with dbt-core 1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Improvements
 * Starting with this release the `dbt-clickhouse` packages will be published to PyPI using Github Actions as a [Trusted Publisher](https://docs.pypi.org/trusted-publishers/). This will improve both the usability and the security of the release process ([#614](https://github.com/ClickHouse/dbt-clickhouse/pull/614)).
-
+* Update dbt core dependencies dbt-adapters from `<1.22.6` to `<1.23.0` and dbt-core from `==1.10.*` to `==1.11.*` for local testing ([#638](https://github.com/ClickHouse/dbt-clickhouse/pull/638))
 
 ### Release [1.10.0], 2026-02-16
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-dbt-core>=1.10.0,<1.11
+dbt-core>=1.11.0,<1.12
 dbt-tests-adapter>=1.10,<2.0
 pytest>=7.2.0
 pytest-dotenv==0.5.2

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-dbt-core>=1.11.0,<1.12
+dbt-core==1.11.*
 dbt-tests-adapter>=1.10,<2.0
 pytest>=7.2.0
 pytest-dotenv==0.5.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "dbt-core>=1.9",
-    "dbt-adapters>=1.22.0,<1.22.6",  # This version should be dbt-adapters<2.0, but keeping it fixed for now to avoid unexpected issues. We need to frequently update it.
+    "dbt-adapters>=1.22.0,<1.23.0",  # This version should be dbt-adapters<2.0, but keeping it fixed for now to avoid unexpected issues. We need to frequently update it.
     "clickhouse-connect>=0.10.0",
     "clickhouse-driver>=0.2.10"
 ]


### PR DESCRIPTION
Increase version of dbt for testing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only change, but moving the test stack to dbt-core 1.11 and a newer dbt-adapters cap can surface integration or macro compatibility issues in CI without touching adapter logic in this PR.
> 
> **Overview**
> Bumps **development and packaging dependency pins** so the project is exercised against **dbt-core 1.11** and a newer **dbt-adapters** line.
> 
> `dev_requirements.txt` now pins **`dbt-core==1.11.*`** instead of the previous `>=1.10.0,<1.11` range. Published dependency bounds in **`pyproject.toml`** widen **`dbt-adapters`** from `<1.22.6` to **`<1.23.0`** (floor remains `>=1.22.0`; **`dbt-core>=1.9`** is unchanged). **`CHANGELOG.md`** records both updates under the upcoming 1.10.1 release ([#638](https://github.com/ClickHouse/dbt-clickhouse/pull/638)).
> 
> There are **no adapter or macro code changes** in this diff—only version constraints and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8cf34ed979318bce924d28e3cbbca7169209730. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->