### PR TITLE
TestReplicatedTableMaterialization flaky fix

### DIFF
--- a/tests/integration/adapter/clickhouse/test_clickhouse_table_materializations.py
+++ b/tests/integration/adapter/clickhouse/test_clickhouse_table_materializations.py
@@ -12,6 +12,7 @@ from dbt.tests.util import (
 )
 
 from tests.integration.adapter.basic.test_basic import base_seeds_schema_yml
+from tests.integration.adapter.helpers import retry_until_assertion_passes
 
 
 class TestMergeTreeTableMaterialization(BaseSimpleMaterializations):
@@ -198,12 +199,18 @@ class TestReplicatedTableMaterialization(BaseSimpleMaterializations):
         )
         assert table_count[0] == host_count[0]
 
-        sum_count = project.run_sql(
-            f"select count() From clusterAllReplicas('{cluster}',{table_relation})",
-            fetch="one",
-        )
+        # ReplicatedMergeTree replication via ZooKeeper is asynchronous: after the
+        # INSERT lands on one node, the other replicas pull the new parts on their
+        # own schedule. Poll clusterAllReplicas until at least two replicas have
+        # caught up to avoid spurious failures (assert 10 >= 20).
+        def check_replicated_row_count():
+            sum_count = project.run_sql(
+                f"select count() From clusterAllReplicas('{cluster}',{table_relation})",
+                fetch="one",
+            )
+            assert sum_count[0] >= 20
 
-        assert sum_count[0] >= 20
+        retry_until_assertion_passes(check_replicated_row_count)
 
     @pytest.mark.skipif(
         os.environ.get('DBT_CH_TEST_CLUSTER', '').strip() == '', reason='Not on a cluster'


### PR DESCRIPTION
Related to https://github.com/ClickHouse/dbt-clickhouse/issues/666

The test was flaky because the replication of the new inserted data was lagging a bit and the replica being checked didn't have the data yet. The fix: retry the check until it A) reaches a more updated replica or B) the replica gets updated with the latests data.