### PR TITLE
[POC] Fix documentation generation by internally filling the database configuration field

### DIFF
--- a/dbt/adapters/clickhouse/credentials.py
+++ b/dbt/adapters/clickhouse/credentials.py
@@ -56,7 +56,13 @@ class ClickHouseCredentials(Credentials):
                 f'On Clickhouse, database must be omitted or have the same value as'
                 f' schema.'
             )
-        self.database = ''
+        # ClickHouse has a single namespace ("database") which the adapter maps
+        # to dbt's "schema". Mirror the schema onto `database` so that
+        # `target.database` and source nodes (whose `database` is sourced from
+        # credentials when not explicitly set) stay in sync with the actual
+        # ClickHouse database. This keeps `manifest.json`, `catalog.json` and
+        # `dbt docs generate` consistent with the data warehouse.
+        self.database = self.schema or ''
 
         # clickhouse_driver expects tcp_keepalive to be a tuple if it's not a boolean
         if isinstance(self.tcp_keepalive, list):

--- a/dbt/adapters/clickhouse/relation.py
+++ b/dbt/adapters/clickhouse/relation.py
@@ -50,8 +50,15 @@ class ClickHouseRelation(BaseRelation):
     )  # List of {'schema', 'name', 'sql'}
 
     def __post_init__(self):
-        if self.database != self.schema and self.database:
-            raise DbtRuntimeError(f'Cannot set database {self.database} in clickhouse!')
+        # ClickHouse has no separate "database" concept above its schema, so any
+        # caller-supplied database is meaningless at the relation level and gets
+        # blanked. We previously raised when database != schema, but that check
+        # is too strict now that credentials.database may legitimately differ
+        # from the relation's schema (callers like the dbt test framework pass
+        # `credentials.database` together with an arbitrary schema, e.g. when
+        # creating alternate schemas). Validation that user-provided
+        # `database` matches `schema` still happens in
+        # ClickHouseCredentials.__post_init__.
         self.path.database = ''
 
     def render(self) -> str:

--- a/dbt/include/clickhouse/macros/adapters.sql
+++ b/dbt/include/clickhouse/macros/adapters.sql
@@ -111,8 +111,23 @@
 {% endmacro %}
 
 
+{#
+  ClickHouse only has a single namespace level (its "database"), which dbt models
+  to dbt's "schema" concept. To keep manifest.json and catalog.json in sync (so
+  that `dbt docs generate` can link catalog rows back to manifest nodes), the
+  resolved database for every node mirrors the resolved schema by reusing
+  generate_schema_name. This way `+schema:` overrides flow through identically.
+#}
 {% macro clickhouse__generate_database_name(custom_database_name=none, node=none) -%}
-  {% do return('') %}
+  {%- if custom_database_name is not none -%}
+    {{ custom_database_name | trim }}
+  {%- else -%}
+    {%- set custom_schema_name = none -%}
+    {%- if node is not none and node.config is not none -%}
+      {%- set custom_schema_name = node.config.get('schema') -%}
+    {%- endif -%}
+    {{ generate_schema_name(custom_schema_name, node) | trim }}
+  {%- endif -%}
 {%- endmacro %}
 
 {% macro clickhouse__get_columns_in_query(select_sql) %}

--- a/dbt/include/clickhouse/macros/catalog.sql
+++ b/dbt/include/clickhouse/macros/catalog.sql
@@ -1,7 +1,7 @@
 {% macro clickhouse__get_catalog(information_schema, schemas) -%}
   {%- call statement('catalog', fetch_result=True) -%}
     select
-      '' as table_database,
+      columns.database as table_database,
       columns.database as table_schema,
       columns.table as table_name,
       if(tables.engine not in ('MaterializedView', 'View'), 'table', 'view') as table_type,

--- a/tests/integration/adapter/basic/test_docs_generate.py
+++ b/tests/integration/adapter/basic/test_docs_generate.py
@@ -10,7 +10,13 @@ from dbt.tests.adapter.basic.test_docs_generate import (
 class TestBaseDocsGenerate(BaseDocsGenerate):
     @pytest.fixture(scope="class")
     def expected_catalog(self, project, profile_user):
-        return base_expected_catalog(
+        # In ClickHouse the "database" namespace and dbt's "schema" are the
+        # same thing, so every node's database equals its actual schema (the
+        # main schema for nodes that live there, the alternate schema for
+        # `second_model` which uses `+schema='test'`). dbt-core's generic
+        # `base_expected_catalog` assumes a separate database concept, so we
+        # rewrite each node's database to match its schema.
+        catalog = base_expected_catalog(
             project,
             role=None,
             id_type="Int32",
@@ -20,6 +26,10 @@ class TestBaseDocsGenerate(BaseDocsGenerate):
             table_type="table",
             model_stats=no_stats(),
         )
+        for section in ("nodes", "sources"):
+            for entry in catalog[section].values():
+                entry["metadata"]["database"] = entry["metadata"]["schema"]
+        return catalog
 
 
 ref_models__schema_yml = """
@@ -148,8 +158,12 @@ def expected_references_catalog(
     if view_summary_stats is None:
         view_summary_stats = model_stats
 
-    model_database = project.database
+    # ClickHouse only has a single namespace ("database"), which the adapter
+    # maps to dbt's "schema". Since `dbt docs generate` now reports the actual
+    # ClickHouse database for each node, we mirror the schema onto database
+    # below instead of using the credentials' database value.
     my_schema_name = case(project.test_schema)
+    model_database = my_schema_name
 
     summary_columns = {
         "first_name": {
@@ -204,7 +218,7 @@ def expected_references_catalog(
                 "unique_id": "seed.test.seed",
                 "metadata": {
                     "schema": my_schema_name,
-                    "database": project.database,
+                    "database": my_schema_name,
                     "name": case("seed"),
                     "type": table_type,
                     "comment": None,
@@ -245,7 +259,7 @@ def expected_references_catalog(
                 "unique_id": "source.test.my_source.my_table",
                 "metadata": {
                     "schema": my_schema_name,
-                    "database": project.database,
+                    "database": my_schema_name,
                     "name": case("seed"),
                     "type": table_type,
                     "comment": None,


### PR DESCRIPTION
# DO NOT MERGE, IT'S NOT SAFE.

This is just a POC to try to understand how many changes would be required to fix https://github.com/ClickHouse/dbt-clickhouse/issues/311

The issue is related to our dbt-clickhouse not filling the `database` field on purpose. dbt uses database, schema and table to reference resources crates in the database but CH only uses 2, database and table. in dbt world, we are using instead schema and table and leave empty database to avoid errors.

This impacts tools that may want to process this information to build information systems.

In this PR I'm trying to see how we can fill the database configuration in some places so:
- 🟡 Users will still not configure it on purpose, only schema should be available and used
- 🟡 Code internally should NOT use the database field, only the schema is the one that needs to be used.
- ✅ The database (being the same name as the schema) is filled in catalog.json and manifest.json files son the `database` tab in the docs actually have data.

We need to make sure all these things are safe before moving forward with this PR