### PR TITLE
feat: add clickhouse__convert_timezone for dbt_date compatibility

### DIFF
--- a/dbt/include/clickhouse/macros/utils/timestamps.sql
+++ b/dbt/include/clickhouse/macros/utils/timestamps.sql
@@ -6,3 +6,10 @@
   {%- set result = "toDateTime('" ~ timestamp ~ "')" -%}
   {{ return(result) }}
 {%- endmacro %}
+
+{%- macro clickhouse__convert_timezone(column, target_tz, source_tz="UTC") -%}
+    toTimeZone(
+        toDateTime({{ column }}, '{{ source_tz }}'),
+        '{{ target_tz }}'
+    )
+{%- endmacro -%}


### PR DESCRIPTION
## Summary

The [`dbt_date` package](https://github.com/calogica/dbt-date) provides a `convert_timezone()` macro that dispatches to `{adapter}__convert_timezone`. ClickHouse is not currently supported, causing `{{ dbt_date.convert_timezone(...) }}` calls to fail with an "Unknown macro" or unsupported adapter error.

This PR adds `clickhouse__convert_timezone` to `utils/timestamps.sql` alongside the existing timestamp utilities.

## Implementation

```jinja
{%- macro clickhouse__convert_timezone(column, target_tz, source_tz="UTC") -%}
    toTimeZone(
        toDateTime({{ column }}, '{{ source_tz }}'),
        '{{ target_tz }}'
    )
{%- endmacro -%}
```

Uses ClickHouse's native `toDateTime(col, tz)` to interpret the source timezone, then `toTimeZone(dt, tz)` to convert — the idiomatic ClickHouse approach.

This implementation was already independently discovered in the [`ClickHouse/jaffle-shop-clickhouse`](https://github.com/ClickHouse/jaffle-shop-clickhouse/blob/main/macros/dbt_date_ch.sql) project, where it lives as a project-level workaround. Moving it into the adapter itself means all dbt-clickhouse users get `dbt_date.convert_timezone()` support without needing a manual override.

## Testing

Confirmed working against ClickHouse 24.3 via the [dbt Fusion ClickHouse adapter](https://github.com/dbt-labs/dbt-core/issues/13168) e2e test suite. The `metricflow_time_spine` model (which uses `dbt_date.convert_timezone`) compiles and runs correctly with this macro in place.