### PR TITLE
feat: Allow `INDEX` syntax sugar for projections with `_part_offset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   * Related to ([#669](https://github.com/ClickHouse/dbt-clickhouse/issues/669), [#670](https://github.com/ClickHouse/dbt-clickhouse/pull/670)).
   * Related PRs:
     * Fix `reuse_connections: false` not actually distributing queries across replicas in the HTTP clinet. `clickhouse-connect` HTTP client shares a process-wide urllib3 `PoolManager` singleton that keeps TCP/TLS sockets alive even after `client.close()`. Each client now gets its own `PoolManager` when `reuse_connections` is disabled, ensuring connections are fully torn down and the load balancer can route the next model to a different replica. ([#686](https://github.com/ClickHouse/dbt-clickhouse/pull/686))
+* Add `index` parameter to the `projections` model config as syntax sugar for lightweight index projections (introduced in ClickHouse 25.6). When `index` is specified instead of `query`, dbt-clickhouse generates the appropriate `ADD PROJECTION` statement automatically: `SELECT _part_offset ORDER BY <cols>` on ClickHouse 25.6–26.0, and the cleaner `INDEX <cols> TYPE basic` syntax on ClickHouse 26.1+. Specifying both `query` and `index`, or neither, raises a compile-time error.
 
 #### Bugs
 * Prevent model-level S3 configuration from mutating profile-level configuration used by subsequent models ([#696](https://github.com/ClickHouse/dbt-clickhouse/pull/696)).

--- a/dbt/include/clickhouse/macros/materializations/distributed_table.sql
+++ b/dbt/include/clickhouse/macros/materializations/distributed_table.sql
@@ -118,32 +118,7 @@
     {% if config.get('projections') %}
       {% set projections = config.get('projections') %}
       {% for projection in projections %}
-        {%- set proj_name = projection.get('name') -%}
-        {%- set proj_query = projection.get('query') -%}
-        {%- set proj_index = projection.get('index') -%}
-        {%- if proj_query and proj_index -%}
-            {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' cannot specify both 'query' and 'index'.") }}
-        {%- elif not proj_query and not proj_index -%}
-            {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' must specify either 'query' or 'index'.") }}
-        {%- elif proj_query -%}
-        , PROJECTION {{ proj_name }} (
-            {{ proj_query }}
-        )
-        {%- else -%}
-            {%- if adapter.is_before_version('25.6.1.1') -%}
-                {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' with 'index' requires '_part_offset' virtual column available from ClickHouse 25.6 onwards.") }}
-            {%- endif -%}
-            {%- if proj_index is string -%}
-                {%- set proj_index = [proj_index] -%}
-            {%- endif -%}
-            {%- set cols_str = proj_index | join(', ') -%}
-            {%- set cols_index_expr = '(' ~ cols_str ~ ')' if proj_index | length > 1 else cols_str -%}
-            {%- if not adapter.is_before_version('26.1.1.1') -%}
-        , PROJECTION {{ proj_name }} INDEX {{ cols_index_expr }} TYPE basic
-            {%- else -%}
-        , PROJECTION {{ proj_name }} (SELECT _part_offset ORDER BY {{ cols_str }})
-            {%- endif -%}
-        {%- endif %}
+        , {{ clickhouse_projection_ddl(projection, keyword='PROJECTION') }}
       {% endfor %}
   {% endif %}
   )

--- a/dbt/include/clickhouse/macros/materializations/distributed_table.sql
+++ b/dbt/include/clickhouse/macros/materializations/distributed_table.sql
@@ -15,6 +15,10 @@
      {% do exceptions.raise_compiler_error('To use distributed materialization cluster setting in dbt profile must be set') %}
   {% endif %}
 
+  {# Distributed materializations drop relations before recreating them, so surface
+     projection config errors here rather than mid-rebuild #}
+  {% do validate_projections() %}
+
   {% set existing_relation_local = existing_relation.incorporate(path={"identifier": this.identifier + local_suffix, "schema": local_db_prefix + this.schema}) if existing_relation is not none else none %}
   {% set target_relation_local = target_relation.incorporate(path={"identifier": this.identifier + local_suffix, "schema": local_db_prefix + this.schema}) if target_relation is not none else none %}
 
@@ -118,7 +122,7 @@
     {% if config.get('projections') %}
       {% set projections = config.get('projections') %}
       {% for projection in projections %}
-        , {{ clickhouse_projection_ddl(projection, keyword='PROJECTION') }}
+        , {{ clickhouse_projection_ddl(projection) }}
       {% endfor %}
   {% endif %}
   )

--- a/dbt/include/clickhouse/macros/materializations/distributed_table.sql
+++ b/dbt/include/clickhouse/macros/materializations/distributed_table.sql
@@ -118,9 +118,32 @@
     {% if config.get('projections') %}
       {% set projections = config.get('projections') %}
       {% for projection in projections %}
-        , PROJECTION {{ projection.get("name") }} (
-            {{ projection.get("query") }}
+        {%- set proj_name = projection.get('name') -%}
+        {%- set proj_query = projection.get('query') -%}
+        {%- set proj_index = projection.get('index') -%}
+        {%- if proj_query and proj_index -%}
+            {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' cannot specify both 'query' and 'index'.") }}
+        {%- elif not proj_query and not proj_index -%}
+            {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' must specify either 'query' or 'index'.") }}
+        {%- elif proj_query -%}
+        , PROJECTION {{ proj_name }} (
+            {{ proj_query }}
         )
+        {%- else -%}
+            {%- if adapter.is_before_version('25.6.1.1') -%}
+                {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' with 'index' requires '_part_offset' virtual column available from ClickHouse 25.6 onwards.") }}
+            {%- endif -%}
+            {%- if proj_index is string -%}
+                {%- set proj_index = [proj_index] -%}
+            {%- endif -%}
+            {%- set cols_str = proj_index | join(', ') -%}
+            {%- set cols_index_expr = '(' ~ cols_str ~ ')' if proj_index | length > 1 else cols_str -%}
+            {%- if not adapter.is_before_version('26.1.1.1') -%}
+        , PROJECTION {{ proj_name }} INDEX {{ cols_index_expr }} TYPE basic
+            {%- else -%}
+        , PROJECTION {{ proj_name }} (SELECT _part_offset ORDER BY {{ cols_str }})
+            {%- endif -%}
+        {%- endif %}
       {% endfor %}
   {% endif %}
   )

--- a/dbt/include/clickhouse/macros/materializations/incremental/distributed_incremental.sql
+++ b/dbt/include/clickhouse/macros/materializations/incremental/distributed_incremental.sql
@@ -15,6 +15,10 @@
      {% do exceptions.raise_compiler_error('To use distributed materializations cluster setting in dbt profile must be set') %}
   {% endif %}
 
+  {# Distributed materializations drop relations before recreating them, so surface
+     projection config errors here rather than mid-rebuild #}
+  {% do validate_projections() %}
+
   {% set existing_relation_local = load_cached_relation(this.incorporate(path={"identifier": this.identifier + local_suffix, "schema": local_db_prefix + this.schema})) %}
   {% set target_relation_local = target_relation.incorporate(path={"identifier": this.identifier + local_suffix, "schema": local_db_prefix + this.schema}) if target_relation is not none else none %}
 

--- a/dbt/include/clickhouse/macros/materializations/table.sql
+++ b/dbt/include/clickhouse/macros/materializations/table.sql
@@ -291,6 +291,33 @@
     It means that this replica still not applied some of previous alters. Probably too many
     alters executing concurrently (highly not recommended).
 #}
+{% macro clickhouse_projection_ddl(projection, keyword='ADD PROJECTION') -%}
+    {%- set proj_name = projection.get('name') -%}
+    {%- set proj_query = projection.get('query') -%}
+    {%- set proj_index = projection.get('index') -%}
+    {%- if proj_query and proj_index -%}
+        {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' cannot specify both 'query' and 'index'.") }}
+    {%- elif not proj_query and not proj_index -%}
+        {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' must specify either 'query' or 'index'.") }}
+    {%- elif proj_query -%}
+        {{ keyword }} {{ proj_name }} ({{ proj_query }})
+    {%- else -%}
+        {%- if adapter.is_before_version('25.6.1.1') -%}
+            {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' with 'index' requires '_part_offset' virtual column available from ClickHouse 25.6 onwards.") }}
+        {%- endif -%}
+        {%- if proj_index is string -%}
+            {%- set proj_index = [proj_index] -%}
+        {%- endif -%}
+        {%- set cols_str = proj_index | join(', ') -%}
+        {%- set cols_index_expr = '(' ~ cols_str ~ ')' if proj_index | length > 1 else cols_str -%}
+        {%- if not adapter.is_before_version('26.1.1.1') -%}
+            {{ keyword }} {{ proj_name }} INDEX {{ cols_index_expr }} TYPE basic
+        {%- else -%}
+            {{ keyword }} {{ proj_name }} (SELECT _part_offset ORDER BY {{ cols_str }})
+        {%- endif -%}
+    {%- endif -%}
+{%- endmacro %}
+
 {% macro add_index_and_projections(relation) %}
     {%- set projections = config.get('projections', default=[]) -%}
     {%- set indexes = config.get('indexes', default=[]) -%}
@@ -300,30 +327,7 @@
             ALTER TABLE {{ relation }}
             {%- if projections %}
                 {%- for projection in projections %}
-                    {%- set proj_name = projection.get('name') -%}
-                    {%- set proj_query = projection.get('query') -%}
-                    {%- set proj_index = projection.get('index') -%}
-                    {%- if proj_query and proj_index -%}
-                        {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' cannot specify both 'query' and 'index'.") }}
-                    {%- elif not proj_query and not proj_index -%}
-                        {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' must specify either 'query' or 'index'.") }}
-                    {%- elif proj_query -%}
-                        ADD PROJECTION {{ proj_name }} ({{ proj_query }})
-                    {%- else -%}
-                        {%- if adapter.is_before_version('25.6.1.1') -%}
-                            {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' with 'index' requires '_part_offset' virtual column available from ClickHouse 25.6 onwards.") }}
-                        {%- endif -%}
-                        {%- if proj_index is string -%}
-                            {%- set proj_index = [proj_index] -%}
-                        {%- endif -%}
-                        {%- set cols_str = proj_index | join(', ') -%}
-                        {%- set cols_index_expr = '(' ~ cols_str ~ ')' if proj_index | length > 1 else cols_str -%}
-                        {%- if not adapter.is_before_version('26.1.1.1') -%}
-                          ADD PROJECTION {{ proj_name }} INDEX {{ cols_index_expr }} TYPE basic
-                        {%- else -%}
-                          ADD PROJECTION {{ proj_name }} (SELECT _part_offset ORDER BY {{ cols_str }})
-                        {%- endif -%}
-                    {%- endif -%}
+                    {{ clickhouse_projection_ddl(projection) }}
                     {%- if not loop.last or indexes | length > 0 -%}
                         ,
                     {% endif %}

--- a/dbt/include/clickhouse/macros/materializations/table.sql
+++ b/dbt/include/clickhouse/macros/materializations/table.sql
@@ -291,8 +291,6 @@
         {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' cannot specify both 'query' and 'index'.") }}
     {%- elif not proj_query and not proj_index -%}
         {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' must specify either 'query' or 'index'.") }}
-    {%- elif proj_index and adapter.is_before_version('25.6.1.1') -%}
-        {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' with 'index' requires '_part_offset' virtual column available from ClickHouse 25.6 onwards.") }}
     {%- endif -%}
 {%- endmacro %}
 

--- a/dbt/include/clickhouse/macros/materializations/table.sql
+++ b/dbt/include/clickhouse/macros/materializations/table.sql
@@ -283,6 +283,50 @@
     {%- endif %}
 {% endmacro %}
 
+{% macro validate_projection(projection) -%}
+    {%- set proj_name = projection.get('name') -%}
+    {%- set proj_query = projection.get('query') -%}
+    {%- set proj_index = projection.get('index') -%}
+    {%- if proj_query and proj_index -%}
+        {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' cannot specify both 'query' and 'index'.") }}
+    {%- elif not proj_query and not proj_index -%}
+        {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' must specify either 'query' or 'index'.") }}
+    {%- elif proj_index and adapter.is_before_version('25.6.1.1') -%}
+        {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' with 'index' requires '_part_offset' virtual column available from ClickHouse 25.6 onwards.") }}
+    {%- endif -%}
+{%- endmacro %}
+
+{# Validates every configured projection without emitting DDL, so materializations
+   can fail fast on bad configs before dropping or renaming any relation. #}
+{% macro validate_projections() -%}
+    {%- for projection in config.get('projections', default=[]) -%}
+        {%- do validate_projection(projection) -%}
+    {%- endfor -%}
+{%- endmacro %}
+
+{# Renders a projection declaration (PROJECTION <name> <body>), the unit shared by
+   CREATE TABLE and ALTER TABLE — ALTER call sites prepend ADD themselves. #}
+{% macro clickhouse_projection_ddl(projection) -%}
+    {%- do validate_projection(projection) -%}
+    {%- set proj_name = projection.get('name') -%}
+    {%- set proj_query = projection.get('query') -%}
+    {%- set proj_index = projection.get('index') -%}
+    {%- if proj_query -%}
+        PROJECTION {{ proj_name }} ({{ proj_query }})
+    {%- else -%}
+        {%- if proj_index is string -%}
+            {%- set proj_index = [proj_index] -%}
+        {%- endif -%}
+        {%- set cols_str = proj_index | join(', ') -%}
+        {%- set cols_index_expr = '(' ~ cols_str ~ ')' if proj_index | length > 1 else cols_str -%}
+        {%- if not adapter.is_before_version('26.1.1.1') -%}
+            PROJECTION {{ proj_name }} INDEX {{ cols_index_expr }} TYPE basic
+        {%- else -%}
+            PROJECTION {{ proj_name }} (SELECT _part_offset ORDER BY {{ cols_str }})
+        {%- endif -%}
+    {%- endif -%}
+{%- endmacro %}
+
 {#
     A macro that adds any configured projections or indexes at the same time.
     We optimise to reduce the number of ALTER TABLE statements that are run to avoid
@@ -291,33 +335,6 @@
     It means that this replica still not applied some of previous alters. Probably too many
     alters executing concurrently (highly not recommended).
 #}
-{% macro clickhouse_projection_ddl(projection, keyword='ADD PROJECTION') -%}
-    {%- set proj_name = projection.get('name') -%}
-    {%- set proj_query = projection.get('query') -%}
-    {%- set proj_index = projection.get('index') -%}
-    {%- if proj_query and proj_index -%}
-        {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' cannot specify both 'query' and 'index'.") }}
-    {%- elif not proj_query and not proj_index -%}
-        {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' must specify either 'query' or 'index'.") }}
-    {%- elif proj_query -%}
-        {{ keyword }} {{ proj_name }} ({{ proj_query }})
-    {%- else -%}
-        {%- if adapter.is_before_version('25.6.1.1') -%}
-            {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' with 'index' requires '_part_offset' virtual column available from ClickHouse 25.6 onwards.") }}
-        {%- endif -%}
-        {%- if proj_index is string -%}
-            {%- set proj_index = [proj_index] -%}
-        {%- endif -%}
-        {%- set cols_str = proj_index | join(', ') -%}
-        {%- set cols_index_expr = '(' ~ cols_str ~ ')' if proj_index | length > 1 else cols_str -%}
-        {%- if not adapter.is_before_version('26.1.1.1') -%}
-            {{ keyword }} {{ proj_name }} INDEX {{ cols_index_expr }} TYPE basic
-        {%- else -%}
-            {{ keyword }} {{ proj_name }} (SELECT _part_offset ORDER BY {{ cols_str }})
-        {%- endif -%}
-    {%- endif -%}
-{%- endmacro %}
-
 {% macro add_index_and_projections(relation) %}
     {%- set projections = config.get('projections', default=[]) -%}
     {%- set indexes = config.get('indexes', default=[]) -%}
@@ -327,7 +344,7 @@
             ALTER TABLE {{ relation }}
             {%- if projections %}
                 {%- for projection in projections %}
-                    {{ clickhouse_projection_ddl(projection) }}
+                    ADD {{ clickhouse_projection_ddl(projection) }}
                     {%- if not loop.last or indexes | length > 0 -%}
                         ,
                     {% endif %}

--- a/dbt/include/clickhouse/macros/materializations/table.sql
+++ b/dbt/include/clickhouse/macros/materializations/table.sql
@@ -70,7 +70,7 @@
           {{ adapter.rename_relation(existing_relation, backup_relation) }}
           {{ adapter.rename_relation(intermediate_relation, target_relation) }}
       {% endif %}
-    
+
     {# If mv_on_schema_change is set, we apply the strategy #}
     {% else %}
       {%- set mv_on_schema_change = incremental_validate_on_schema_change(configured_mv_on_schema_change, default='ignore') -%}
@@ -86,7 +86,7 @@
         {% endif %}
       {%- endif %}
     {% endif %}
-  
+
   {# Behaviour under full_refresh operations #}
   {% else %}
     {# Atomic full refresh with MV repopulation: when table is target of dbt MVs and repopulate_from_mvs_on_full_refresh is enabled #}
@@ -300,7 +300,30 @@
             ALTER TABLE {{ relation }}
             {%- if projections %}
                 {%- for projection in projections %}
-                    ADD PROJECTION {{ projection.get('name') }} ({{ projection.get('query') }})
+                    {%- set proj_name = projection.get('name') -%}
+                    {%- set proj_query = projection.get('query') -%}
+                    {%- set proj_index = projection.get('index') -%}
+                    {%- if proj_query and proj_index -%}
+                        {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' cannot specify both 'query' and 'index'.") }}
+                    {%- elif not proj_query and not proj_index -%}
+                        {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' must specify either 'query' or 'index'.") }}
+                    {%- elif proj_query -%}
+                        ADD PROJECTION {{ proj_name }} ({{ proj_query }})
+                    {%- else -%}
+                        {%- if adapter.is_before_version('25.6.1.1') -%}
+                            {{ exceptions.raise_compiler_error("Projection '" ~ proj_name ~ "' with 'index' requires '_part_offset' virtual column available from ClickHouse 25.6 onwards.") }}
+                        {%- endif -%}
+                        {%- if proj_index is string -%}
+                            {%- set proj_index = [proj_index] -%}
+                        {%- endif -%}
+                        {%- set cols_str = proj_index | join(', ') -%}
+                        {%- set cols_index_expr = '(' ~ cols_str ~ ')' if proj_index | length > 1 else cols_str -%}
+                        {%- if not adapter.is_before_version('26.1.1.1') -%}
+                          ADD PROJECTION {{ proj_name }} INDEX {{ cols_index_expr }} TYPE basic
+                        {%- else -%}
+                          ADD PROJECTION {{ proj_name }} (SELECT _part_offset ORDER BY {{ cols_str }})
+                        {%- endif -%}
+                    {%- endif -%}
                     {%- if not loop.last or indexes | length > 0 -%}
                         ,
                     {% endif %}

--- a/tests/integration/adapter/helpers.py
+++ b/tests/integration/adapter/helpers.py
@@ -19,8 +19,12 @@ def below_version(major: int, minor: int = 0, _ch_test_version_value: Optional[s
         or os.environ.get('DBT_CH_TEST_CH_VERSION', '0.0')
         or '0.0'  # Extra 0.0 to make Mypy happy
     )
-    actual_major, actual_minor = current_version.split('.')
-    return int(actual_major) < major or (int(actual_major) == major and int(actual_minor) < minor)
+    parts = current_version.split('.')
+    try:
+        actual_major, actual_minor = int(parts[0]), int(parts[1])
+    except (IndexError, ValueError):
+        return False  # treat 'latest', 'head', etc. as above any version threshold
+    return actual_major < major or (actual_major == major and actual_minor < minor)
 
 
 retry_config = TypedDict('retry_config', {'max_retries': int, 'delay': float})

--- a/tests/integration/adapter/helpers.py
+++ b/tests/integration/adapter/helpers.py
@@ -19,12 +19,8 @@ def below_version(major: int, minor: int = 0, _ch_test_version_value: Optional[s
         or os.environ.get('DBT_CH_TEST_CH_VERSION', '0.0')
         or '0.0'  # Extra 0.0 to make Mypy happy
     )
-    parts = current_version.split('.')
-    try:
-        actual_major, actual_minor = int(parts[0]), int(parts[1])
-    except (IndexError, ValueError):
-        return False  # treat 'latest', 'head', etc. as above any version threshold
-    return actual_major < major or (actual_major == major and actual_minor < minor)
+    actual_major, actual_minor = current_version.split('.')
+    return int(actual_major) < major or (int(actual_major) == major and int(actual_minor) < minor)
 
 
 retry_config = TypedDict('retry_config', {'max_retries': int, 'delay': float})

--- a/tests/integration/adapter/projections/test_projections.py
+++ b/tests/integration/adapter/projections/test_projections.py
@@ -424,7 +424,11 @@ class TestDistributedProjectionValidationPreservesTable:
             "cannot specify both 'query' and 'index'" in (r.message or "") for r in res.results
         )
 
-        # Both the distributed proxy and the underlying local table must survive
+        # Both the distributed proxy and the underlying local tables must survive.
         assert project.run_sql(count_query, fetch="one")[0] == 5
-        local_count_query = f"SELECT count(*) FROM {project.test_schema}.{relation.name}_local"
-        assert project.run_sql(local_count_query, fetch="one")[0] == 5
+        cluster = os.environ.get("DBT_CH_TEST_CLUSTER", "").strip()
+        local_count_query = (
+            f"SELECT count(*) FROM clusterAllReplicas('{cluster}', "
+            f"{project.test_schema}.{relation.name}_local)"
+        )
+        assert project.run_sql(local_count_query, fetch="one")[0] >= 5

--- a/tests/integration/adapter/projections/test_projections.py
+++ b/tests/integration/adapter/projections/test_projections.py
@@ -369,6 +369,7 @@ class TestIndexProjectionValidation:
         )
 
     def test_raises_when_neither_query_nor_index(self, project):
+        run_dbt(["seed"])
         res = run_dbt(["run", "--select", "no_query_or_index"], expect_pass=False)
         assert any(
             "must specify either 'query' or 'index'" in (r.message or "") for r in res.results

--- a/tests/integration/adapter/projections/test_projections.py
+++ b/tests/integration/adapter/projections/test_projections.py
@@ -346,7 +346,9 @@ class TestIndexProjections:
             assert len(result) == 1
 
 
-class TestIndexProjectionValidation:
+class BaseIndexProjectionValidation:
+    materialized = "table"
+
     @pytest.fixture(scope="class")
     def seeds(self):
         return {
@@ -357,8 +359,12 @@ class TestIndexProjectionValidation:
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "both_query_and_index.sql": PEOPLE_MODEL_WITH_QUERY_AND_INDEX,
-            "no_query_or_index.sql": PEOPLE_MODEL_WITH_NO_QUERY_OR_INDEX,
+            "both_query_and_index.sql": PEOPLE_MODEL_WITH_QUERY_AND_INDEX.replace(
+                "materialized='table'", f"materialized='{self.materialized}'"
+            ),
+            "no_query_or_index.sql": PEOPLE_MODEL_WITH_NO_QUERY_OR_INDEX.replace(
+                "materialized='table'", f"materialized='{self.materialized}'"
+            ),
         }
 
     def test_raises_when_both_query_and_index(self, project):
@@ -374,3 +380,11 @@ class TestIndexProjectionValidation:
         assert any(
             "must specify either 'query' or 'index'" in (r.message or "") for r in res.results
         )
+
+
+class TestIndexProjectionValidation(BaseIndexProjectionValidation):
+    pass
+
+
+class TestDistributedIndexProjectionValidation(BaseIndexProjectionValidation):
+    materialized = "distributed_table"

--- a/tests/integration/adapter/projections/test_projections.py
+++ b/tests/integration/adapter/projections/test_projections.py
@@ -3,7 +3,7 @@ import os
 import uuid
 
 import pytest
-from dbt.tests.util import relation_from_name, run_dbt
+from dbt.tests.util import relation_from_name, run_dbt, write_file
 
 from tests.integration.adapter.helpers import (
     DEFAULT_RETRY_CONFIG,
@@ -392,3 +392,45 @@ class TestIndexProjectionValidation(BaseIndexProjectionValidation):
 )
 class TestDistributedIndexProjectionValidation(BaseIndexProjectionValidation):
     materialized = "distributed_table"
+
+
+@pytest.mark.skipif(
+    os.environ.get("DBT_CH_TEST_CLUSTER", "").strip() == "",
+    reason="Not on a cluster",
+)
+class TestDistributedProjectionValidationPreservesTable:
+    """A projection config error must fail before the materialization drops or
+    renames anything, leaving the previously built model fully queryable."""
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "people.csv": PEOPLE_SEED_CSV,
+            "schema.yml": SEED_SCHEMA_YML,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"people_distributed.sql": PEOPLE_MODEL_WITH_PROJECTION % "distributed_table"}
+
+    def test_invalid_config_leaves_existing_model_intact(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run", "--select", "people_distributed"])
+
+        relation = relation_from_name(project.adapter, "people_distributed")
+        count_query = f"SELECT count(*) FROM {project.test_schema}.{relation.name}"
+        assert project.run_sql(count_query, fetch="one")[0] == 5
+
+        invalid_model = PEOPLE_MODEL_WITH_QUERY_AND_INDEX.replace(
+            "materialized='table'", "materialized='distributed_table'"
+        )
+        write_file(invalid_model, project.project_root, "models", "people_distributed.sql")
+        res = run_dbt(["run", "--select", "people_distributed"], expect_pass=False)
+        assert any(
+            "cannot specify both 'query' and 'index'" in (r.message or "") for r in res.results
+        )
+
+        # Both the distributed proxy and the underlying local table must survive
+        assert project.run_sql(count_query, fetch="one")[0] == 5
+        local_count_query = f"SELECT count(*) FROM {project.test_schema}.{relation.name}_local"
+        assert project.run_sql(local_count_query, fetch="one")[0] == 5

--- a/tests/integration/adapter/projections/test_projections.py
+++ b/tests/integration/adapter/projections/test_projections.py
@@ -386,5 +386,9 @@ class TestIndexProjectionValidation(BaseIndexProjectionValidation):
     pass
 
 
+@pytest.mark.skipif(
+    os.environ.get("DBT_CH_TEST_CLUSTER", "").strip() == "",
+    reason="Not on a cluster",
+)
 class TestDistributedIndexProjectionValidation(BaseIndexProjectionValidation):
     materialized = "distributed_table"

--- a/tests/integration/adapter/projections/test_projections.py
+++ b/tests/integration/adapter/projections/test_projections.py
@@ -1,4 +1,3 @@
-import contextlib
 import os
 import uuid
 
@@ -7,7 +6,6 @@ from dbt.tests.util import relation_from_name, run_dbt, write_file
 
 from tests.integration.adapter.helpers import (
     DEFAULT_RETRY_CONFIG,
-    below_version,
     retry_until_assertion_passes,
 )
 
@@ -332,18 +330,14 @@ class TestIndexProjections:
     )
     def test_index_projection(self, project, model_name, proj_name):
         run_dbt(["seed"])
-        unsupported_version = below_version(25, 6)
-        ctx = pytest.raises(AssertionError) if unsupported_version else contextlib.nullcontext()
-        with ctx:
-            run_dbt(["run", "--select", model_name])
-        if not unsupported_version:
-            result = project.run_sql(
-                f"SELECT name FROM system.projections "
-                f"WHERE database = '{project.test_schema}' "
-                f"AND table = '{model_name}' AND name = '{proj_name}'",
-                fetch="all",
-            )
-            assert len(result) == 1
+        run_dbt(["run", "--select", model_name])
+        result = project.run_sql(
+            f"SELECT name FROM system.projections "
+            f"WHERE database = '{project.test_schema}' "
+            f"AND table = '{model_name}' AND name = '{proj_name}'",
+            fetch="all",
+        )
+        assert len(result) == 1
 
 
 class BaseIndexProjectionValidation:

--- a/tests/integration/adapter/projections/test_projections.py
+++ b/tests/integration/adapter/projections/test_projections.py
@@ -1,10 +1,15 @@
+import contextlib
 import os
 import uuid
 
 import pytest
 from dbt.tests.util import relation_from_name, run_dbt
 
-from tests.integration.adapter.helpers import DEFAULT_RETRY_CONFIG, retry_until_assertion_passes
+from tests.integration.adapter.helpers import (
+    DEFAULT_RETRY_CONFIG,
+    below_version,
+    retry_until_assertion_passes,
+)
 
 PEOPLE_SEED_CSV = """
 id,name,age,department
@@ -67,9 +72,61 @@ sources:
       - name: people
 """
 
+PEOPLE_MODEL_WITH_SINGLE_INDEX_PROJECTION = """
+{{ config(
+       materialized='table',
+       order_by='id',
+       projections=[
+           {
+               'name': 'proj_by_age',
+               'index': 'age'
+           }
+       ]
+) }}
+select id, name, age, department from {{ source('raw', 'people') }}
+"""
+
+PEOPLE_MODEL_WITH_MULTI_COLUMN_INDEX_PROJECTION = """
+{{ config(
+       materialized='table',
+       order_by='id',
+       projections=[
+           {
+               'name': 'proj_by_dept_age',
+               'index': ['department', 'age']
+           }
+       ]
+) }}
+select id, name, age, department from {{ source('raw', 'people') }}
+"""
+
+PEOPLE_MODEL_WITH_QUERY_AND_INDEX = """
+{{ config(
+       materialized='table',
+       order_by='id',
+       projections=[
+           {
+               'name': 'bad_proj',
+               'query': 'SELECT department ORDER BY department',
+               'index': 'age'
+           }
+       ]
+) }}
+select id, name, age, department from {{ source('raw', 'people') }}
+"""
+
+PEOPLE_MODEL_WITH_NO_QUERY_OR_INDEX = """
+{{ config(
+       materialized='table',
+       order_by='id',
+       projections=[{'name': 'bad_proj'}]
+) }}
+select id, name, age, department from {{ source('raw', 'people') }}
+"""
+
 RETRY_CONFIG = (
-    {'max_retries': 30, 'delay': 1}
-    if os.environ.get('DBT_CH_TEST_CLOUD', '').lower() in ('1', 'true', 'yes')
+    {"max_retries": 30, "delay": 1}
+    if os.environ.get("DBT_CH_TEST_CLOUD", "").lower() in ("1", "true", "yes")
     else DEFAULT_RETRY_CONFIG
 )
 
@@ -95,13 +152,13 @@ class TestProjections:
     def _get_table_reference(self, table: str) -> str:
         return (
             table
-            if os.environ.get('DBT_CH_TEST_CLUSTER', '').strip() == ''
+            if os.environ.get("DBT_CH_TEST_CLUSTER", "").strip() == ""
             else f"clusterAllReplicas({os.environ.get('DBT_CH_TEST_CLUSTER')}, {table})"
         )
 
     def _flush_system_logs(self, project) -> None:
-        cluster = os.environ.get('DBT_CH_TEST_CLUSTER', '').strip()
-        cluster_clause = f'ON CLUSTER "{cluster}"' if cluster else ''
+        cluster = os.environ.get("DBT_CH_TEST_CLUSTER", "").strip()
+        cluster_clause = f'ON CLUSTER "{cluster}"' if cluster else ""
         project.run_sql(f"SYSTEM FLUSH LOGS {cluster_clause}", fetch="all")
 
     def test_create_and_verify_projection(self, project):
@@ -117,7 +174,11 @@ class TestProjections:
         # Check that the projection works as expected
         result = project.run_sql(query, fetch="all")
         assert len(result) == 3  # We expect 3 departments in the result
-        assert result == [('engineering', 43.666666666666664), ('malware', 40.0), ('sales', 25.0)]
+        assert result == [
+            ("engineering", 43.666666666666664),
+            ("malware", 40.0),
+            ("sales", 25.0),
+        ]
 
         # check that the latest query used the projection
         def check_that_the_latest_query_used_the_projection():
@@ -131,7 +192,7 @@ class TestProjections:
             assert len(result) > 0
             assert query in result[0][0]
 
-            assert result[0][1] == [f'{project.test_schema}.{relation.name}.projection_avg_age']
+            assert result[0][1] == [f"{project.test_schema}.{relation.name}.projection_avg_age"]
 
         retry_until_assertion_passes(
             check_that_the_latest_query_used_the_projection, **RETRY_CONFIG
@@ -152,7 +213,11 @@ class TestProjections:
         # Check that the projection works as expected
         result = project.run_sql(query, fetch="all")
         assert len(result) == 3  # We expect 3 departments in the result
-        assert result == [('engineering', 43.666666666666664), ('malware', 40.0), ('sales', 25.0)]
+        assert result == [
+            ("engineering", 43.666666666666664),
+            ("malware", 40.0),
+            ("sales", 25.0),
+        ]
 
         # check that the latest query used the projection
         def check_that_the_latest_query_used_the_projection():
@@ -166,7 +231,7 @@ class TestProjections:
             assert len(result) > 0
             assert query in result[0][0]
 
-            assert result[0][1] == [f'{project.test_schema}.{relation.name}.projection_avg_age']
+            assert result[0][1] == [f"{project.test_schema}.{relation.name}.projection_avg_age"]
 
         retry_until_assertion_passes(
             check_that_the_latest_query_used_the_projection, **RETRY_CONFIG
@@ -181,7 +246,7 @@ class TestProjections:
         # Check that the projection works as expected
         result = project.run_sql(query, fetch="all")
         assert len(result) == 3  # We expect 3 departments in the result
-        assert result == [('engineering', 131), ('malware', 40), ('sales', 25)]
+        assert result == [("engineering", 131), ("malware", 40), ("sales", 25)]
 
         def check_that_the_latest_query_used_the_projection():
             self._flush_system_logs(project)
@@ -194,7 +259,7 @@ class TestProjections:
             assert len(result) > 0
             assert query in result[0][0]
 
-            assert result[0][1] == [f'{project.test_schema}.{relation.name}.projection_sum_age']
+            assert result[0][1] == [f"{project.test_schema}.{relation.name}.projection_sum_age"]
 
         retry_until_assertion_passes(
             check_that_the_latest_query_used_the_projection, **RETRY_CONFIG
@@ -202,7 +267,8 @@ class TestProjections:
 
     @pytest.mark.xfail
     @pytest.mark.skipif(
-        os.environ.get('DBT_CH_TEST_CLUSTER', '').strip() == '', reason='Not on a cluster'
+        os.environ.get("DBT_CH_TEST_CLUSTER", "").strip() == "",
+        reason="Not on a cluster",
     )
     def test_create_and_verify_distributed_projection(self, project):
         run_dbt(["seed"])
@@ -216,7 +282,11 @@ class TestProjections:
         # Check that the projection works as expected
         result = project.run_sql(query, fetch="all")
         assert len(result) == 3  # We expect 3 departments in the result
-        assert result == [('engineering', 43.666666666666664), ('malware', 40.0), ('sales', 25.0)]
+        assert result == [
+            ("engineering", 43.666666666666664),
+            ("malware", 40.0),
+            ("sales", 25.0),
+        ]
 
         def check_that_the_latest_query_used_the_projection():
             self._flush_system_logs(project)
@@ -230,9 +300,76 @@ class TestProjections:
             assert query in result[0][0]
 
             assert result[0][1] == [
-                f'{project.test_schema}.{relation.name}_local.projection_avg_age'
+                f"{project.test_schema}.{relation.name}_local.projection_avg_age"
             ]
 
         retry_until_assertion_passes(
             check_that_the_latest_query_used_the_projection, **RETRY_CONFIG
+        )
+
+
+class TestIndexProjections:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "people.csv": PEOPLE_SEED_CSV,
+            "schema.yml": SEED_SCHEMA_YML,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "people_with_index_projection.sql": PEOPLE_MODEL_WITH_SINGLE_INDEX_PROJECTION,
+            "people_with_multi_index_projection.sql": PEOPLE_MODEL_WITH_MULTI_COLUMN_INDEX_PROJECTION,
+        }
+
+    @pytest.mark.parametrize(
+        "model_name, proj_name",
+        [
+            ("people_with_index_projection", "proj_by_age"),
+            ("people_with_multi_index_projection", "proj_by_dept_age"),
+        ],
+    )
+    def test_index_projection(self, project, model_name, proj_name):
+        run_dbt(["seed"])
+        unsupported_version = below_version(25, 6)
+        ctx = pytest.raises(AssertionError) if unsupported_version else contextlib.nullcontext()
+        with ctx:
+            run_dbt(["run", "--select", model_name])
+        if not unsupported_version:
+            result = project.run_sql(
+                f"SELECT name FROM system.projections "
+                f"WHERE database = '{project.test_schema}' "
+                f"AND table = '{model_name}' AND name = '{proj_name}'",
+                fetch="all",
+            )
+            assert len(result) == 1
+
+
+class TestIndexProjectionValidation:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "people.csv": PEOPLE_SEED_CSV,
+            "schema.yml": SEED_SCHEMA_YML,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "both_query_and_index.sql": PEOPLE_MODEL_WITH_QUERY_AND_INDEX,
+            "no_query_or_index.sql": PEOPLE_MODEL_WITH_NO_QUERY_OR_INDEX,
+        }
+
+    def test_raises_when_both_query_and_index(self, project):
+        run_dbt(["seed"])
+        res = run_dbt(["run", "--select", "both_query_and_index"], expect_pass=False)
+        assert any(
+            "cannot specify both 'query' and 'index'" in (r.message or "") for r in res.results
+        )
+
+    def test_raises_when_neither_query_nor_index(self, project):
+        res = run_dbt(["run", "--select", "no_query_or_index"], expect_pass=False)
+        assert any(
+            "must specify either 'query' or 'index'" in (r.message or "") for r in res.results
         )


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
* Add `index` parameter to `projections` model config to allow setting index projections nicer.
* Using `ADD PROJECTION my_projection INDEX my, columns TYPE basic` if ClickHouse 26.1+
* Using `ADD PROJECTION my_projection (SELECT _part_offset ORDER BY my, columns)` if ClickHouse 25.6+
* Raise error if ClickHouse <25.6
* Black has formatted the modified files, modifying a few bits in unmodified functions.
* Fixes https://github.com/ClickHouse/dbt-clickhouse/issues/650 

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [x] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials - https://github.com/ClickHouse/clickhouse-docs/pull/6546

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to projection DDL generation in table materialization with backward-compatible `query` behavior and compile-time guards; main risk is wrong version-specific SQL on edge ClickHouse versions.
> 
> **Overview**
> Adds an optional **`index`** field on each entry in the `projections` model config so you can declare lightweight index projections without writing raw `ADD PROJECTION` SQL. The **`add_index_and_projections`** macro still emits `ADD PROJECTION … (query)` when **`query`** is set; with **`index`** only, it builds version-specific DDL: **`INDEX … TYPE basic`** on ClickHouse **26.1+**, or **`(SELECT _part_offset ORDER BY …)`** on **25.6–26.0**. Compile-time errors block **`query` + `index`**, missing both, or **`index`** on servers before **25.6**. The **1.10.1** changelog documents the feature; integration tests cover happy paths, validation messages, and version gating (existing projection tests were reformatted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06962eb5462c69abe308ce82341d0d7915bee44f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->