### PR TITLE
perf: Optimise schema introspection when listing MVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Improvements
 * Starting with this release the `dbt-clickhouse` packages will be published to PyPI using Github Actions as a [Trusted Publisher](https://docs.pypi.org/trusted-publishers/). This will improve both the usability and the security of the release process ([#614](https://github.com/ClickHouse/dbt-clickhouse/pull/614)).
 * Populate `query_id` in `AdapterResponse` for every executed query. The query ID is generated as a UUID4 and forwarded to ClickHouse, making it available via `adapter_response` in dbt artifacts and enabling tools like Elementary to correlate dbt model runs with entries in `system.query_log`.
+* Reduce schema introspection time by batching relation cache population into a single query instead of one per schema. The `mv_sources` CTE is also pre-filtered to only scan MVs relevant to the requested schemas ([#654](https://github.com/ClickHouse/dbt-clickhouse/pull/654)).
 
 
 ### Release [1.10.0], 2026-02-16

--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -350,40 +350,55 @@ class ClickHouseAdapter(SQLAdapter):
     ) -> List[ClickHouseRelation]:
         kwargs = {'schema_relation': schema_relation}
         results = self.execute_macro('list_relations_without_caching', kwargs=kwargs)
-        conn_supports_exchange = self.supports_atomic_exchange()
+        return [self._row_to_relation(row) for row in results]
 
-        cluster_configured = bool(self.get_clickhouse_cluster_name())
+    def _row_to_relation(self, row) -> ClickHouseRelation:
+        name, schema, type_info, db_engine, mvs_pointing_to_it, on_cluster = row
+        if type_info == 'materialized_view':
+            rel_type = ClickHouseRelationType.MaterializedView
+        elif type_info == 'view':
+            rel_type = ClickHouseRelationType.View
+        elif type_info == 'dictionary':
+            rel_type = ClickHouseRelationType.Dictionary
+        else:
+            rel_type = ClickHouseRelationType.Table
+        can_exchange = (
+            self.supports_atomic_exchange()
+            and rel_type == ClickHouseRelationType.Table
+            and engine_can_atomic_exchange(db_engine)
+        )
+        can_on_cluster = (
+            bool(self.get_clickhouse_cluster_name()) or on_cluster >= 1
+        ) and db_engine != 'Replicated'
+        return self.Relation.create(
+            database='',
+            schema=schema,
+            identifier=name,
+            type=rel_type,
+            can_exchange=can_exchange,
+            can_on_cluster=can_on_cluster,
+            mvs_pointing_to_it=json.loads(mvs_pointing_to_it) or [],
+        )
 
-        relations = []
+    def _relations_cache_for_schemas(
+        self,
+        relation_configs: Iterable[RelationConfig],
+        cache_schemas=None,
+    ) -> None:
+        if not cache_schemas:
+            cache_schemas = self._get_cache_schemas(relation_configs)
+        if not cache_schemas:
+            return
+
+        results = self.execute_macro(
+            'clickhouse__list_relations_for_schemas',
+            kwargs={'schema_relations': list(cache_schemas)},
+        )
         for row in results:
-            name, schema, type_info, db_engine, mvs_pointing_to_it, on_cluster = row
-            if type_info == 'materialized_view':
-                rel_type = ClickHouseRelationType.MaterializedView
-            elif type_info == 'view':
-                rel_type = ClickHouseRelationType.View
-            elif type_info == 'dictionary':
-                rel_type = ClickHouseRelationType.Dictionary
-            else:
-                rel_type = ClickHouseRelationType.Table
-            can_exchange = (
-                conn_supports_exchange
-                and rel_type == ClickHouseRelationType.Table
-                and engine_can_atomic_exchange(db_engine)
-            )
-            can_on_cluster = (cluster_configured or on_cluster >= 1) and db_engine != 'Replicated'
+            self.cache.add(self._row_to_relation(row))
 
-            relation = self.Relation.create(
-                database='',
-                schema=schema,
-                identifier=name,
-                type=rel_type,
-                can_exchange=can_exchange,
-                can_on_cluster=can_on_cluster,
-                mvs_pointing_to_it=json.loads(mvs_pointing_to_it) or [],
-            )
-            relations.append(relation)
-
-        return relations
+        cache_update = {(r.database, r.schema) for r in cache_schemas if r.schema}
+        self.cache.update_schemas(cache_update)
 
     def get_relation(self, database: Optional[str], schema: str, identifier: str):
         return super().get_relation('', schema, identifier)

--- a/dbt/include/clickhouse/macros/adapters.sql
+++ b/dbt/include/clickhouse/macros/adapters.sql
@@ -20,21 +20,27 @@
 {% endmacro %}
 
 {% macro clickhouse__list_relations_without_caching(schema_relation) %}
-  {% call statement('list_relations_without_caching', fetch_result=True) -%}
+  {{ return(clickhouse__list_relations_for_schemas([schema_relation])) }}
+{% endmacro %}
+
+{% macro clickhouse__list_relations_for_schemas(schema_relations) %}
+  {%- set schemas = schema_relations | map(attribute='schema') | list -%}
+  {%- set cluster = adapter.get_clickhouse_cluster_name() -%}
+  {% call statement('list_relations_for_schemas', fetch_result=True) -%}
     with mv_sources as (
-      -- Find all MVs and their target tables (database and name of the MV, plus the SELECT SQL)
       select
         name as mv_name,
         database as mv_database,
         any(as_select) as mv_sql,
         any(replaceRegexpOne(create_table_query, '.*TO\\s+`?([^`\\s(]+)`?\\.`?([^`\\s(]+)`?.*', '\\1.\\2')) as target_fqn
-      {% if adapter.get_clickhouse_cluster_name() -%}
-      from clusterAllReplicas({{ adapter.get_clickhouse_cluster_name() }}, system.tables)
+      {% if cluster -%}
+      from clusterAllReplicas({{ cluster }}, system.tables)
       {% else %}
       from system.tables
       {% endif %}
       where engine = 'MaterializedView'
         and create_table_query like '%TO %'
+        and ({% for s in schemas %}create_table_query like '%{{ s }}%'{% if not loop.last %} or {% endif %}{% endfor %})
       group by mv_name, mv_database
     )
     select
@@ -51,20 +57,20 @@
         map('schema', mv_sources.mv_database, 'name', mv_sources.mv_name, 'sql', mv_sources.mv_sql),
         mv_sources.mv_name != ''
       ) as mvs_pointing_to_it,
-      {%- if adapter.get_clickhouse_cluster_name() -%}
-        count(distinct _shard_num) > 1  as  is_on_cluster
-        from clusterAllReplicas({{ adapter.get_clickhouse_cluster_name() }}, system.tables) as t
+      {%- if cluster -%}
+        count(distinct _shard_num) > 1 as is_on_cluster
+        from clusterAllReplicas({{ cluster }}, system.tables) as t
       {%- else -%}
         0 as is_on_cluster
         from system.tables as t
       {% endif %}
         join system.databases as db on t.database = db.name
         left join mv_sources on mv_sources.target_fqn = concat(t.database, '.', t.name)
-      where schema = '{{ schema_relation.schema }}'
+      where schema in ({% for s in schemas %}'{{ s }}'{% if not loop.last %}, {% endif %}{% endfor %})
       group by name, schema, type, db_engine
 
   {% endcall %}
-  {{ return(load_result('list_relations_without_caching').table) }}
+  {{ return(load_result('list_relations_for_schemas').table) }}
 {% endmacro %}
 
 {% macro clickhouse__get_columns_in_relation(relation) -%}

--- a/tests/unit/test_mv_listing.py
+++ b/tests/unit/test_mv_listing.py
@@ -1,0 +1,99 @@
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from dbt.adapters.clickhouse.impl import ClickHouseAdapter
+from dbt.adapters.clickhouse.relation import ClickHouseRelation, ClickHouseRelationType
+
+
+def _make_row(name, schema, type_info='table', db_engine='Atomic', mvs='[]', on_cluster=0):
+    return (name, schema, type_info, db_engine, mvs, on_cluster)
+
+
+@pytest.fixture
+def adapter():
+    a = MagicMock(spec=ClickHouseAdapter)
+    a.Relation = ClickHouseRelation
+    a.supports_atomic_exchange.return_value = True
+    a.get_clickhouse_cluster_name.return_value = None
+    a.cache = MagicMock()
+    a._get_cache_schemas = MagicMock()
+    a.execute_macro = MagicMock()
+    return a
+
+
+def test_row_to_relation_table(adapter):
+    row = _make_row('orders', 'staging')
+    rel = ClickHouseAdapter._row_to_relation(adapter, row)
+    assert rel.identifier == 'orders'
+    assert rel.schema == 'staging'
+    assert rel.type == ClickHouseRelationType.Table
+    assert rel.can_exchange is True
+
+
+def test_row_to_relation_view(adapter):
+    row = _make_row('my_view', 'staging', type_info='view')
+    rel = ClickHouseAdapter._row_to_relation(adapter, row)
+    assert rel.type == ClickHouseRelationType.View
+    assert rel.can_exchange is False
+
+
+def test_row_to_relation_mv_with_sources(adapter):
+    mvs = json.dumps([{'schema': 'raw', 'name': 'mv_orders', 'sql': 'SELECT 1'}])
+    row = _make_row('orders', 'staging', mvs=mvs)
+    rel = ClickHouseAdapter._row_to_relation(adapter, row)
+    assert len(rel.mvs_pointing_to_it) == 1
+    assert rel.mvs_pointing_to_it[0]['name'] == 'mv_orders'
+
+
+def test_relations_cache_for_schemas_single_macro_call(adapter):
+    schema_a = MagicMock(schema='staging', database='')
+    schema_b = MagicMock(schema='marts', database='')
+    cache_schemas = {schema_a, schema_b}
+
+    adapter.execute_macro.return_value = [
+        _make_row('orders', 'staging'),
+        _make_row('customers', 'marts'),
+    ]
+
+    ClickHouseAdapter._relations_cache_for_schemas(adapter, [], cache_schemas=cache_schemas)
+
+    adapter.execute_macro.assert_called_once_with(
+        'clickhouse__list_relations_for_schemas',
+        kwargs={'schema_relations': list(cache_schemas)},
+    )
+    assert adapter.cache.add.call_count == 2
+
+
+def test_relations_cache_for_schemas_updates_schemas(adapter):
+    schema_a = MagicMock(schema='staging', database='')
+    schema_b = MagicMock(schema='marts', database='')
+    cache_schemas = {schema_a, schema_b}
+
+    adapter.execute_macro.return_value = []
+
+    ClickHouseAdapter._relations_cache_for_schemas(adapter, [], cache_schemas=cache_schemas)
+
+    adapter.cache.update_schemas.assert_called_once_with({('', 'staging'), ('', 'marts')})
+
+
+def test_relations_cache_for_schemas_empty(adapter):
+    adapter._get_cache_schemas.return_value = set()
+    ClickHouseAdapter._relations_cache_for_schemas(adapter, [])
+    adapter.execute_macro.assert_not_called()
+
+
+def test_list_relations_without_caching(adapter):
+    schema_relation = MagicMock(schema='staging', database='')
+    adapter.execute_macro.return_value = [
+        _make_row('orders', 'staging'),
+        _make_row('my_view', 'staging', type_info='view'),
+    ]
+
+    relations = ClickHouseAdapter.list_relations_without_caching(adapter, schema_relation)
+
+    adapter.execute_macro.assert_called_once_with(
+        'list_relations_without_caching',
+        kwargs={'schema_relation': schema_relation},
+    )
+    assert len(relations) == 2


### PR DESCRIPTION
## Summary

Reduce schema introspection time by batching relation cache population into a single query instead of one per schema. Closes #652.

The base adapter fans out `list_relations_without_caching` once per schema via a thread pool. Each call scans `system.tables` independently — including a full `mv_sources` CTE that reads `create_table_query` for every MV in the instance regardless of schema.

**Changes:**
- Override `_relations_cache_for_schemas` to call a new `clickhouse__list_relations_for_schemas` macro that resolves all schemas in a single round-trip
- Add `LIKE` pre-filter on `mv_sources` to scope the MV scan to relevant schemas
- `clickhouse__list_relations_without_caching` becomes a thin wrapper around the new macro (preserves dispatch for downstream overrides)
- Extract `_row_to_relation` helper shared by both paths

Measured with `dbt ls` on a 13-schema project: **8.4s → 3.1s**.

## Checklist

- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes core relation-listing and caching SQL/macros, which could affect catalog/introspection correctness or performance on large/odd schema names and clustered setups.
> 
> **Overview**
> Speeds up schema introspection by batching relation cache population across multiple schemas in a single macro call, rather than running one query per schema.
> 
> Introduces `clickhouse__list_relations_for_schemas` (used by `clickhouse__list_relations_without_caching`) and updates the adapter to build relations via a shared `_row_to_relation` helper, while updating cache schema tracking after the batch load. The MV discovery CTE is also pre-filtered to only scan materialized views likely relevant to the requested schemas.
> 
> Adds unit tests covering `_row_to_relation` parsing, batched cache population behavior, and the wrapper `list_relations_without_caching` path, and documents the change in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c79a601a7eedd944934446e72e7e478c18526ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->