### PR TITLE
feat: suppot table clone with `dbt clone` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Replaced legacy `docker-compose` commands with `docker compose` (V2)
 * Updated GitHub Actions workflow to use Docker Compose V2
 * Reduce connection startup overhead from the `EXCHANGE TABLES` capability check. On ClickHouse Cloud (Shared engine), the check now short-circuits immediately after detecting the engine — skipping 5 DDL round-trips (2× `CREATE TABLE`, `EXCHANGE TABLES`, 2× `DROP TABLE`) that were previously run on every connection open. For all other engine types, the result is cached behind a process-level lock so the DDL test runs at most once per dbt invocation regardless of thread count. ([#653](https://github.com/ClickHouse/dbt-clickhouse/pull/653)).
+* Support the `dbt clone` command for tables. Tables backed by a MergeTree-family engine are cloned with ClickHouse's zero-copy `CREATE OR REPLACE TABLE ... CLONE AS ...`; other engines and Distributed tables fall back to dbt's view behavior ([#655](https://github.com/ClickHouse/dbt-clickhouse/pull/655)).
+
 
 ### Release [1.10.0], 2026-02-16
 

--- a/dbt/include/clickhouse/macros/materializations/clone.sql
+++ b/dbt/include/clickhouse/macros/materializations/clone.sql
@@ -3,5 +3,5 @@
 {% endmacro %}
 
 {% macro clickhouse__create_or_replace_clone(this_relation, defer_relation) %}
-    create or replace table {{ this_relation.render() }} {{ on_cluster_clause(this_relation)}} as {{ defer_relation.render() }}
+    CREATE OR REPLACE TABLE {{ this_relation.render() }} {{ on_cluster_clause(this_relation)}} CLONE AS {{ defer_relation.render() }}
 {% endmacro %}

--- a/dbt/include/clickhouse/macros/materializations/clone.sql
+++ b/dbt/include/clickhouse/macros/materializations/clone.sql
@@ -3,5 +3,5 @@
 {% endmacro %}
 
 {% macro clickhouse__create_or_replace_clone(this_relation, defer_relation) %}
-    create or replace table  {{ on_cluster_clause(relation)}} {{ this_relation.render() }} as {{ defer_relation.render() }}
+    create or replace table {{ this_relation.render() }} {{ on_cluster_clause(this_relation)}} as {{ defer_relation.render() }}
 {% endmacro %}

--- a/dbt/include/clickhouse/macros/materializations/clone.sql
+++ b/dbt/include/clickhouse/macros/materializations/clone.sql
@@ -1,0 +1,7 @@
+{% macro clickhouse__can_clone_table() %}
+    {{ return(True) }}
+{% endmacro %}
+
+{% macro clickhouse__create_or_replace_clone(this_relation, defer_relation) %}
+    create or replace table  {{ on_cluster_clause(relation)}} {{ this_relation.render() }} as {{ defer_relation.render() }}
+{% endmacro %}

--- a/dbt/include/clickhouse/macros/materializations/clone.sql
+++ b/dbt/include/clickhouse/macros/materializations/clone.sql
@@ -1,7 +1,18 @@
 {% macro clickhouse__can_clone_table() %}
-    {{ return(True) }}
+    {#
+        Clone behavior with ClickHouse (dbt clone only operates on 'table'-type materializations, for the rest it falls back to view):
+        - *MergeTree tables  -> cloned via `CLONE AS`.
+        - Tables with other engines -> not supported, fall back to a view.
+        - Distributed tables -> not supported, fall back to a view.
+        - Materialized views -> only the target table is cloned; now MV is crated/attached to the clon.
+    #}
+    {%- if config.get('materialized', '').startswith('distributed_') -%}
+        {{ return(False) }}
+    {%- endif -%}
+    {%- set engine = config.get('engine', default='MergeTree()') -%}
+    {{ return('MergeTree' in engine) }}
 {% endmacro %}
 
 {% macro clickhouse__create_or_replace_clone(this_relation, defer_relation) %}
-    CREATE OR REPLACE TABLE {{ this_relation.render() }} {{ on_cluster_clause(this_relation)}} CLONE AS {{ defer_relation.render() }}
+    CREATE OR REPLACE TABLE {{ this_relation }} {{ on_cluster_clause(this_relation) }} CLONE AS {{ defer_relation }}
 {% endmacro %}

--- a/tests/integration/adapter/dbt_clone/test_dbt_clone.py
+++ b/tests/integration/adapter/dbt_clone/test_dbt_clone.py
@@ -1,5 +1,107 @@
-from dbt.tests.adapter.dbt_clone.test_dbt_clone import BaseClonePossible
+import pytest
+from dbt.tests.adapter.dbt_clone import fixtures
+from dbt.tests.adapter.dbt_clone.test_dbt_clone import (
+    BaseClone,
+    BaseCloneNotPossible,
+    BaseClonePossible,
+    BaseCloneSameSourceAndTarget,
+    BaseCloneSameTargetAndState,
+)
+from dbt.tests.util import run_dbt, run_dbt_and_capture
 
 
 class TestBaseClonePossible(BaseClonePossible):
     pass
+
+
+class TestCloneNotPossible(BaseCloneNotPossible):
+    pass
+
+
+class TestCloneSameTargetAndState(BaseCloneSameTargetAndState):
+    pass
+
+
+class TestCloneSameSourceAndTarget(BaseCloneSameSourceAndTarget):
+    # The upstream base class declares `models`/`snapshots` as plain methods (the
+    # `@pytest.fixture` decorator is missing), and its test uses Postgres-style
+    # three-part names and an engine-less `CREATE TABLE ... AS SELECT`. Re-declare
+    # the fixtures properly and override the test with ClickHouse-valid SQL.
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "source_based_model.sql": fixtures.source_based_model_sql,
+            "source_schema.yml": fixtures.source_schema_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def snapshots(self):
+        return {}
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {}
+
+    def test_clone_same_source_and_target(self, project, unique_schema):
+        """Cloning a relation onto itself should be skipped, not executed."""
+        project.run_sql(f"DROP TABLE IF EXISTS {unique_schema}.source_table")
+        project.run_sql(
+            f"""
+            CREATE TABLE {unique_schema}.source_table
+            ENGINE = MergeTree
+            ORDER BY id
+            AS
+            SELECT 1 AS id, 'test_data' AS name
+            UNION ALL
+            SELECT 2 AS id, 'more_data' AS name
+            """
+        )
+
+        run_dbt(["run"])
+
+        # Save state, then clone with the default target (same schema as state)
+        self.copy_state(project.project_root)
+        clone_args = ["clone", "--state", "state", "--full-refresh", "--log-level", "debug"]
+
+        _, output = run_dbt_and_capture(clone_args)
+
+        assert "skipping clone for relation" in output
+
+
+class TestCloneNonMergeTreeBecomesView(BaseClone):
+    """A non-MergeTree table cannot be cloned with `CLONE AS`, so dbt-core should
+    fall back to materializing it as a view in the target schema."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "memory_model.sql": "{{ config(materialized='table', engine='Memory') }}\n"
+            "select 1 as id, 'a' as name",
+        }
+
+    @pytest.fixture(scope="class")
+    def snapshots(self):
+        return {}
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {}
+
+    def test_non_mergetree_not_cloned_as_table(self, project, unique_schema, other_schema):
+        project.create_test_schema(other_schema)
+
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        self.copy_state(project.project_root)
+
+        clone_args = ["clone", "--state", "state", "--target", "otherschema"]
+        results = run_dbt(clone_args)
+        assert len(results) == 1
+
+        schema_relations = project.adapter.list_relations(
+            database=project.database, schema=other_schema
+        )
+        # Memory is not a MergeTree-family engine, so the clone falls back to a view
+        # rather than being cloned as a table.
+        assert len(schema_relations) == 1
+        assert all(r.type == "view" for r in schema_relations)

--- a/tests/integration/adapter/dbt_clone/test_dbt_clone.py
+++ b/tests/integration/adapter/dbt_clone/test_dbt_clone.py
@@ -1,7 +1,5 @@
-import pytest
 from dbt.tests.adapter.dbt_clone.test_dbt_clone import BaseClonePossible
 
 
-@pytest.mark.skip("clone not supported")
 class TestBaseClonePossible(BaseClonePossible):
     pass


### PR DESCRIPTION
Resolves #389

Replicate the schema and data of an existing table ([docs link](https://clickhouse.com/docs/sql-reference/statements/create/table#with-a-schema-and-data-cloned-from-another-table))

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces DDL that replaces tables in the target (including optional ON CLUSTER); incorrect eligibility logic could clone unsupported engines or skip valid MergeTree variants.
> 
> **Overview**
> Adds **`dbt clone`** support for ClickHouse table models via new adapter macros in `clone.sql`.
> 
> **`clickhouse__can_clone_table`** returns true when the model is a table with a MergeTree-family `engine` (default `MergeTree()`), and false for `distributed_*` materializations or non-MergeTree engines so dbt-core falls back to view behavior.
> 
> **`clickhouse__create_or_replace_clone`** runs `CREATE OR REPLACE TABLE ... [ON CLUSTER] CLONE AS ...` for eligible tables (zero-copy schema + data clone).
> 
> Integration tests no longer skip clone: they wire up dbt-core’s clone test bases, add a ClickHouse-specific same-source/target skip test, and assert **Memory** engine models clone as **views** in the target schema. **CHANGELOG** documents the feature for 1.10.1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6452b66bee137cde326241d4c3f36e9a0651802. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->