### PR TITLE
Add ClickHouse catalog relations support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Updated GitHub Actions workflow to use Docker Compose V2
 * Reduce connection startup overhead from the `EXCHANGE TABLES` capability check. On ClickHouse Cloud (Shared engine), the check now short-circuits immediately after detecting the engine — skipping 5 DDL round-trips (2× `CREATE TABLE`, `EXCHANGE TABLES`, 2× `DROP TABLE`) that were previously run on every connection open. For all other engine types, the result is cached behind a process-level lock so the DDL test runs at most once per dbt invocation regardless of thread count. ([#653](https://github.com/ClickHouse/dbt-clickhouse/pull/653)).
 * Support the `dbt clone` command for tables. Tables backed by a MergeTree-family engine are cloned with ClickHouse's zero-copy `CREATE OR REPLACE TABLE ... CLONE AS ...`; other engines and Distributed tables fall back to dbt's view behavior ([#655](https://github.com/ClickHouse/dbt-clickhouse/pull/655)).
+* Add relation-scoped catalog metadata support with `clickhouse__get_catalog_relations`.
 
 
 ### Release [1.10.0], 2026-02-16

--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -76,7 +76,7 @@ class ClickHouseAdapter(SQLAdapter):
 
     _capabilities: CapabilityDict = CapabilityDict(
         {
-            Capability.SchemaMetadataByRelations: CapabilitySupport(support=Support.Unsupported),
+            Capability.SchemaMetadataByRelations: CapabilitySupport(support=Support.Full),
             Capability.TableLastModifiedMetadata: CapabilitySupport(support=Support.Unsupported),
         }
     )
@@ -419,7 +419,15 @@ class ClickHouseAdapter(SQLAdapter):
         used_schemas: FrozenSet[Tuple[str, str]],
         relations: Optional[Set[BaseRelation]] = None,
     ):
-        catalog, exceptions = self.get_catalog(relation_configs, used_schemas)
+        if (
+            relations is None
+            or len(relations) > self.MAX_SCHEMA_METADATA_RELATIONS
+            or not self.supports(Capability.SchemaMetadataByRelations)
+        ):
+            catalog, exceptions = self.get_catalog(relation_configs, used_schemas)
+        else:
+            catalog, exceptions = self.get_catalog_by_relations(used_schemas, relations)
+
         if relations and catalog:
             relation_map = {(r.schema, r.identifier) for r in relations}
 

--- a/dbt/include/clickhouse/macros/catalog.sql
+++ b/dbt/include/clickhouse/macros/catalog.sql
@@ -1,26 +1,18 @@
 {% macro clickhouse__get_catalog(information_schema, schemas) -%}
   {%- call statement('catalog', fetch_result=True) -%}
-    {{ clickhouse__get_catalog_schemas_sql(information_schema, schemas) }}
+    {{ get_catalog_results_sql(get_catalog_schemas_where_clause_sql(schemas)) }}
   {%- endcall -%}
   {{ return(load_result('catalog').table) }}
 {%- endmacro %}
 
 {% macro clickhouse__get_catalog_relations(information_schema, relations) -%}
   {%- call statement('catalog', fetch_result=True) -%}
-    {{ clickhouse__get_catalog_relations_sql(information_schema, relations) }}
+    {{ get_catalog_results_sql(get_catalog_relations_where_clause_sql(relations)) }}
   {%- endcall -%}
   {{ return(load_result('catalog').table) }}
 {%- endmacro %}
 
-{% macro clickhouse__get_catalog_schemas_sql(information_schema, schemas) -%}
-  {{ clickhouse__get_catalog_results_sql(clickhouse__get_catalog_schemas_where_clause_sql(schemas)) }}
-{%- endmacro %}
-
-{% macro clickhouse__get_catalog_relations_sql(information_schema, relations) -%}
-  {{ clickhouse__get_catalog_results_sql(clickhouse__get_catalog_relations_where_clause_sql(relations)) }}
-{%- endmacro %}
-
-{% macro clickhouse__get_catalog_results_sql(where_clause) -%}
+{% macro get_catalog_results_sql(where_clause) -%}
     select
       '' as table_database,
       columns.database as table_schema,
@@ -38,7 +30,7 @@
     order by columns.database, columns.table, columns.position
 {%- endmacro %}
 
-{% macro clickhouse__get_catalog_schemas_where_clause_sql(schemas) -%}
+{% macro get_catalog_schemas_where_clause_sql(schemas) -%}
   {% if schemas | length == 0 %}
     where 1 = 0
   {% else %}
@@ -52,7 +44,7 @@
   {% endif %}
 {%- endmacro %}
 
-{% macro clickhouse__get_catalog_relations_where_clause_sql(relations) -%}
+{% macro get_catalog_relations_where_clause_sql(relations) -%}
   {% if relations | length == 0 %}
     where 1 = 0
   {% else %}

--- a/dbt/include/clickhouse/macros/catalog.sql
+++ b/dbt/include/clickhouse/macros/catalog.sql
@@ -1,5 +1,26 @@
 {% macro clickhouse__get_catalog(information_schema, schemas) -%}
   {%- call statement('catalog', fetch_result=True) -%}
+    {{ clickhouse__get_catalog_schemas_sql(information_schema, schemas) }}
+  {%- endcall -%}
+  {{ return(load_result('catalog').table) }}
+{%- endmacro %}
+
+{% macro clickhouse__get_catalog_relations(information_schema, relations) -%}
+  {%- call statement('catalog', fetch_result=True) -%}
+    {{ clickhouse__get_catalog_relations_sql(information_schema, relations) }}
+  {%- endcall -%}
+  {{ return(load_result('catalog').table) }}
+{%- endmacro %}
+
+{% macro clickhouse__get_catalog_schemas_sql(information_schema, schemas) -%}
+  {{ clickhouse__get_catalog_results_sql(clickhouse__get_catalog_schemas_where_clause_sql(schemas)) }}
+{%- endmacro %}
+
+{% macro clickhouse__get_catalog_relations_sql(information_schema, relations) -%}
+  {{ clickhouse__get_catalog_results_sql(clickhouse__get_catalog_relations_where_clause_sql(relations)) }}
+{%- endmacro %}
+
+{% macro clickhouse__get_catalog_results_sql(where_clause) -%}
     select
       '' as table_database,
       columns.database as table_schema,
@@ -13,14 +34,45 @@
       null as table_owner
     from system.columns as columns
     join system.tables as tables on tables.database = columns.database and tables.name = columns.table
-    where database != 'system' and
-    (
-    {%- for schema in schemas -%}
-      columns.database = '{{ schema }}'
-      {%- if not loop.last %} or {% endif -%}
-    {%- endfor -%}
-    )
+    {{ where_clause }}
     order by columns.database, columns.table, columns.position
-  {%- endcall -%}
-  {{ return(load_result('catalog').table) }}
+{%- endmacro %}
+
+{% macro clickhouse__get_catalog_schemas_where_clause_sql(schemas) -%}
+  {% if schemas | length == 0 %}
+    where 1 = 0
+  {% else %}
+    where columns.database != 'system'
+      and (
+      {%- for schema in schemas -%}
+        columns.database = '{{ schema }}'
+        {%- if not loop.last %} or {% endif -%}
+      {%- endfor -%}
+      )
+  {% endif %}
+{%- endmacro %}
+
+{% macro clickhouse__get_catalog_relations_where_clause_sql(relations) -%}
+  {% if relations | length == 0 %}
+    where 1 = 0
+  {% else %}
+    where columns.database != 'system'
+      and (
+      {%- for relation in relations -%}
+        {% if not relation.schema %}
+          {% do exceptions.raise_compiler_error(
+            '`get_catalog_relations` requires a list of relations, each with a schema'
+          ) %}
+        {% endif %}
+
+        (
+          columns.database = '{{ relation.schema }}'
+          {%- if relation.identifier %}
+          and columns.table = '{{ relation.identifier }}'
+          {%- endif %}
+        )
+        {%- if not loop.last %} or {% endif -%}
+      {%- endfor -%}
+      )
+  {% endif %}
 {%- endmacro %}

--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -1,0 +1,45 @@
+from unittest.mock import MagicMock
+
+from dbt.adapters.capability import Capability
+from dbt.adapters.clickhouse.impl import ClickHouseAdapter
+from dbt.adapters.clickhouse.relation import ClickHouseRelation
+
+
+class FakeCatalog:
+    def __init__(self):
+        self.predicate = None
+
+    def __bool__(self):
+        return True
+
+    def where(self, predicate):
+        self.predicate = predicate
+        return self
+
+
+class FakeRow(dict):
+    pass
+
+
+def test_schema_metadata_by_relations_is_supported():
+    assert ClickHouseAdapter.supports(Capability.SchemaMetadataByRelations)
+
+
+def test_get_filtered_catalog_uses_relation_scoped_fetch_for_small_relation_sets():
+    adapter = ClickHouseAdapter.__new__(ClickHouseAdapter)
+    catalog = FakeCatalog()
+    relations = {ClickHouseRelation.create(schema='analytics', identifier='orders')}
+    used_schemas = frozenset()
+
+    adapter.get_catalog = MagicMock(return_value=('schema-catalog', []))
+    adapter.get_catalog_by_relations = MagicMock(return_value=(catalog, []))
+
+    result, exceptions = adapter.get_filtered_catalog([], used_schemas, relations=relations)
+
+    assert result is catalog
+    assert exceptions == []
+    adapter.get_catalog.assert_not_called()
+    adapter.get_catalog_by_relations.assert_called_once_with(used_schemas, relations)
+    assert catalog.predicate is not None
+    assert catalog.predicate(FakeRow(table_schema='analytics', table_name='orders'))
+    assert not catalog.predicate(FakeRow(table_schema='analytics', table_name='customers'))


### PR DESCRIPTION
## Summary

- add `clickhouse__get_catalog_relations` for relation-scoped catalog metadata fetches
- mark `SchemaMetadataByRelations` as fully supported and route small filtered catalog requests through the relation-scoped path
- add unit coverage for the capability and dispatch choice

## Rationale

This follows the catalog fetch performance work introduced in the dbt Core adapter maintainer discussion: https://github.com/dbt-labs/dbt-core/discussions/8307#:~:text=Catalog%20fetch%20performance%20improvements

`get_catalog_relations()` lets an adapter fetch metadata for the exact relations dbt needs instead of scanning every object in every requested schema. This was useful but not mission critical for dbt Core adapters; it is more important in Fusion because catalog metadata lookup sits on a hotter interactive path where broad warehouse metadata scans are much harder for users to reason about.

Before this PR, dbt-clickhouse declared `SchemaMetadataByRelations` unsupported and used a schema-scoped catalog fetch plus Python post-filtering fallback. This switches to the simpler relation-scoped SQL macro, aligning dbt-clickhouse with the Fusion ClickHouse implementation in dbt-labs/fs#10553 and dbt-labs/dbt-fusion#2224.

## Validation

- `uv run --with-editable . --with-requirements dev_requirements.txt make lint`
- `uv run --no-project --python /Users/dataders/Developer/dbt-clickhouse/dev-env/.venv/bin/python python -m pytest tests/unit/test_catalog.py`
- `uv run --no-project --python /Users/dataders/Developer/dataface/.venv/bin/python python -m black --check dbt/adapters/clickhouse/impl.py tests/unit/test_catalog.py`
- `uv run --no-project python -m py_compile tests/unit/test_catalog.py dbt/adapters/clickhouse/impl.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-query routing and macro refactor only; large relation sets still fall back to schema-scoped catalog with existing Python filtering.
> 
> **Overview**
> Adds **relation-scoped catalog metadata** so dbt can query `system.columns` / `system.tables` for specific relations instead of whole schemas.
> 
> The adapter now advertises **`SchemaMetadataByRelations` as fully supported** and **`get_filtered_catalog`** uses **`get_catalog_by_relations`** when the relation set is present, within **`MAX_SCHEMA_METADATA_RELATIONS`**, and the capability is enabled; otherwise it keeps the schema-wide path. **`catalog.sql`** is refactored so **`clickhouse__get_catalog`** and the new **`clickhouse__get_catalog_relations`** share **`get_catalog_results_sql`**, with separate schema- vs relation-based `WHERE` builders (relations without a schema raise a compiler error).
> 
> Unit tests cover the capability flag and the relation-scoped dispatch; the changelog notes the feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3bd186092c080c2c536b3e7ad5888242a0d349c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->