### PR TITLE
Update clickhouse version matrix

### DIFF
--- a/.github/workflows/test_local_matrix.yml
+++ b/.github/workflows/test_local_matrix.yml
@@ -20,16 +20,16 @@ jobs:
         # Testing ClickHouse versions with active security support https://github.com/ClickHouse/ClickHouse/blob/master/SECURITY.md
         clickhouse-version:
           # lts will get tested will all supported python versions
-          - '25.3'
           - '25.8'
+          - '26.3'
         include:
           # Rest of supported versions will get tested only with latest python version to reduce the number of jobs needed
           - python-version: '3.12'
-            clickhouse-version: '25.10'
+            clickhouse-version: '26.3'
           - python-version: '3.12'
-            clickhouse-version: '25.11'
+            clickhouse-version: '26.4'
           - python-version: '3.12'
-            clickhouse-version: '25.12'
+            clickhouse-version: '26.5'
           - python-version: '3.12'
             clickhouse-version: 'latest'
           - python-version: '3.12'

--- a/.github/workflows/test_local_matrix.yml
+++ b/.github/workflows/test_local_matrix.yml
@@ -25,8 +25,6 @@ jobs:
         include:
           # Rest of supported versions will get tested only with latest python version to reduce the number of jobs needed
           - python-version: '3.12'
-            clickhouse-version: '26.3'
-          - python-version: '3.12'
             clickhouse-version: '26.4'
           - python-version: '3.12'
             clickhouse-version: '26.5'


### PR DESCRIPTION
## Summary
Update list to include current security supported versions https://github.com/clickhouse/clickhouse/security

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only CI workflow matrix pins change; no application or runtime code is affected.
> 
> **Overview**
> Updates the **local CI matrix** in `test_local_matrix.yml` so integration tests track **currently security-supported ClickHouse releases** per ClickHouse’s security policy.
> 
> **LTS axis:** drops `25.3` and adds **`26.3`** alongside `25.8` (both still run across all Python versions).
> 
> **Python 3.12-only pins:** removes `25.10`, `25.11`, and `25.12`; adds **`26.4`** and **`26.5`**. **`latest`** and **`head`** jobs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dd1027da474826c7bde6b41f6733d2d1b26c902. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->