### PR TITLE
Fix replace partition error from version >26.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Unreleased
+
+#### Bug Fixes
+* Fix the `insert_overwrite` incremental strategy failing on ClickHouse 26.6+ with `Code: 36 ... refusing REPLACE PARTITION because it would silently drop the destination partition's data`. The strategy intentionally replaces partitions from a source table that may have no parts for a partition (to clear shards that received no new data on distributed tables), which newer servers reject by default. The `REPLACE PARTITION` statement now includes `allow_replace_partition_from_empty_source=1` on servers 26.6 and newer; older servers keep their existing behavior.
+
 ### Release [1.10.1], 2026-06-16
 
 #### Improvements

--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -159,6 +159,15 @@ class ClickHouseAdapter(SQLAdapter):
             return compare_versions(version, server_version) > 0
         return False
 
+    @available
+    def is_at_or_after_version(self, version: str) -> bool:
+        """True if the server version is at or after (inclusive) the given version."""
+        conn = self.connections.get_if_exists()
+        if conn:
+            server_version = conn.handle.server_version
+            return compare_versions(server_version, version) >= 0
+        return False
+
     @available.parse_none
     def supports_atomic_exchange(self) -> bool:
         conn = self.connections.get_if_exists()

--- a/dbt/include/clickhouse/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/clickhouse/macros/materializations/incremental/incremental.sql
@@ -296,6 +296,12 @@
                 from {{ new_data_relation }}
                 {{- ', ' if not loop.last }}
             {%- endfor %}
+            {#- The strategy relies on REPLACE PARTITION from a source with no parts in the partition
+                to clear shards that received no new data. ClickHouse 26.6+ refuses that by default,
+                so opt back in. Older servers don't know the setting and would reject the query. -#}
+            {%- if not adapter.is_before_version('26.6') %}
+                settings allow_replace_partition_from_empty_source = 1
+            {%- endif %}
       {% endcall %}
     {% endif %}
 

--- a/dbt/include/clickhouse/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/clickhouse/macros/materializations/incremental/incremental.sql
@@ -299,7 +299,7 @@
             {#- The strategy relies on REPLACE PARTITION from a source with no parts in the partition
                 to clear shards that received no new data. ClickHouse 26.6+ refuses that by default,
                 so opt back in. Older servers don't know the setting and would reject the query. -#}
-            {%- if not adapter.is_before_version('26.6') %}
+            {%- if adapter.is_at_or_after_version('26.6') %}
                 settings allow_replace_partition_from_empty_source = 1
             {%- endif %}
       {% endcall %}

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,6 +1,29 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+import pytest
+from dbt.adapters.clickhouse.impl import ClickHouseAdapter
 from dbt.adapters.clickhouse.util import compare_versions, hide_stack_trace
+
+
+def _adapter_with_server_version(server_version: str) -> ClickHouseAdapter:
+    adapter = ClickHouseAdapter.__new__(ClickHouseAdapter)
+    conn = MagicMock()
+    conn.handle.server_version = server_version
+    adapter.connections = MagicMock()
+    adapter.connections.get_if_exists.return_value = conn
+    return adapter
+
+
+@pytest.mark.parametrize(
+    'server_version,version,expected',
+    [
+        ('26.6.1.1193', '26.6', True),  # partial threshold matches inclusively
+        ('26.5.9.10', '26.6', False),
+    ],
+)
+def test_is_at_or_after_version(server_version, version, expected):
+    adapter = _adapter_with_server_version(server_version)
+    assert adapter.is_at_or_after_version(version) is expected
 
 
 def test_is_before_version():


### PR DESCRIPTION
## Summary
Fix the `insert_overwrite` incremental strategy failing on ClickHouse 26.6+ with `Code: 36 ... refusing REPLACE PARTITION because it would silently drop the destination partition's data`. The strategy intentionally replaces partitions from a source table that may have no parts for a partition (to clear shards that received no new data on distributed tables), which newer servers reject by default. The `REPLACE PARTITION` statement now includes `allow_replace_partition_from_empty_source=1` on servers 26.6 and newer; older servers keep their existing behavior.

I went with the simplest solution: Just add the setting for this specific use case as we explicitly want this one to behave this way. Not touching other queries in case we want to have a different behaviour for them.

Avoided other possible implementations with the focus to keep it simple:
- Checking if the setting is available by checking existing settings: Just checking by version is enough.
- Adding it to the list of current settings applied: Many required changes to do that for just this one.
