### PR TITLE
 Update refreshable MV parameters on dbt run via MODIFY REFRESH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Release [1.10.2], 2026-XX-XX
 
 #### Improvements
+* Refresh parameters of refreshable materialized views (`interval`, `randomize`, `depends_on`) are now updated in place on every `dbt run` using `ALTER TABLE ... MODIFY REFRESH`, the same way the MV query is updated via `MODIFY QUERY`. Previously, changing them required `dbt run --full-refresh`, which dropped and recreated the MV. Changes that ClickHouse cannot apply in place — converting a regular MV to a refreshable one (or back), and toggling the `append` setting — now fail with a clear error asking for a `--full-refresh` run instead of being silently ignored ([#611](https://github.com/ClickHouse/dbt-clickhouse/issues/611)).
 * Add a `reuse_connections` profile option (default `true`). When set to `false`, dbt closes the connection after each model so the next opens a fresh one. This is useful for multi-replica ClickHouse Cloud where connection-sticky load balancing would otherwise pin a `dbt run` to one replica. Per-model reconnects are kept cheap by doing some changes that also optimized regular multi-threaded runs:
   * Caching the `EXISTS DATABASE` probe.
   * Caching the `allow_nondeterministic_mutations` capability probe process-wide.

--- a/dbt/adapters/clickhouse/impl.py
+++ b/dbt/adapters/clickhouse/impl.py
@@ -359,7 +359,16 @@ class ClickHouseAdapter(SQLAdapter):
 
         relations = []
         for row in results:
-            name, schema, type_info, db_engine, mvs_pointing_to_it, on_cluster = row
+            (
+                name,
+                schema,
+                type_info,
+                db_engine,
+                mvs_pointing_to_it,
+                is_refreshable,
+                refreshable_append,
+                on_cluster,
+            ) = row
             if type_info == 'materialized_view':
                 rel_type = ClickHouseRelationType.MaterializedView
             elif type_info == 'view':
@@ -383,6 +392,8 @@ class ClickHouseAdapter(SQLAdapter):
                 can_exchange=can_exchange,
                 can_on_cluster=can_on_cluster,
                 mvs_pointing_to_it=json.loads(mvs_pointing_to_it) or [],
+                is_refreshable=bool(is_refreshable),
+                refreshable_append=bool(refreshable_append),
             )
             relations.append(relation)
 

--- a/dbt/adapters/clickhouse/relation.py
+++ b/dbt/adapters/clickhouse/relation.py
@@ -48,6 +48,10 @@ class ClickHouseRelation(BaseRelation):
     mvs_pointing_to_it: List[Dict[str, str]] = field(
         default_factory=list
     )  # List of {'schema', 'name', 'sql'}
+    # Populated from the deployed DDL when the relation is loaded from the database cache;
+    # relations built any other way default to False.
+    is_refreshable: bool = False
+    refreshable_append: bool = False
 
     def __post_init__(self):
         if self.database != self.schema and self.database:

--- a/dbt/include/clickhouse/macros/adapters.sql
+++ b/dbt/include/clickhouse/macros/adapters.sql
@@ -51,6 +51,10 @@
         map('schema', mv_sources.mv_database, 'name', mv_sources.mv_name, 'sql', mv_sources.mv_sql),
         mv_sources.mv_name != ''
       ) as mvs_pointing_to_it,
+      -- The refresh clause of a refreshable MV sits between the view name and the TO clause,
+      -- e.g. CREATE MATERIALIZED VIEW db.mv REFRESH EVERY 2 MINUTE [APPEND] TO db.target ...
+      max(position(substring(t.create_table_query, 1, position(t.create_table_query, ' TO ')), ' REFRESH ')) > 0 as is_refreshable,
+      max(position(substring(t.create_table_query, 1, position(t.create_table_query, ' TO ')), ' APPEND')) > 0 as refreshable_append,
       {%- if adapter.get_clickhouse_cluster_name() -%}
         count(distinct _shard_num) > 1  as  is_on_cluster
         from clusterAllReplicas({{ adapter.get_clickhouse_cluster_name() }}, system.tables) as t

--- a/dbt/include/clickhouse/macros/materializations/materialized_view.sql
+++ b/dbt/include/clickhouse/macros/materializations/materialized_view.sql
@@ -114,7 +114,7 @@
     {% endif %}
 
     {{ log('Updating query of existing MV ' ~ mv_relation.name ~ ' for recreation') }}
-    -- We should also update refreshable paramenters here https://github.com/ClickHouse/dbt-clickhouse/issues/611
+    {{ clickhouse__modify_mv_refresh(mv_relation, existing_relation, cluster_clause) }}
     {{ clickhouse__modify_mv(mv_relation, cluster_clause, sql, is_main_statement=True) }};
     {%- set view_created = False -%}
   {% endif %}
@@ -340,9 +340,55 @@
   {{ return(none) }}
 {% endmacro %}
 
+{#-
+  Applies refresh parameter changes to an existing refreshable MV in place via
+  ALTER TABLE ... MODIFY REFRESH (https://github.com/ClickHouse/dbt-clickhouse/issues/611).
+  Like MODIFY QUERY, the statement is issued on every run without diffing: it replaces the
+  whole schedule (interval, randomization and dependencies), so it is idempotent.
+  The deployed state comes from the cached relation (is_refreshable / refreshable_append),
+  so no extra round trip to ClickHouse is needed. Transitions that ClickHouse cannot apply
+  in place (regular <-> refreshable, APPEND <-> non-APPEND) raise an error pointing the
+  user to --full-refresh instead of being silently ignored.
+-#}
+{% macro clickhouse__modify_mv_refresh(mv_relation, existing_relation, cluster_clause) %}
+  {%- set refreshable_config = config.get('refreshable') -%}
+
+  {% if refreshable_config is none %}
+    {% if existing_relation.is_refreshable %}
+      {% do exceptions.raise_compiler_error(
+        'Materialized view "' ~ mv_relation.name ~ '" is refreshable, but the model does not define a "refreshable" config. '
+        ~ 'A refreshable MV cannot be converted to a regular MV in place. '
+        ~ 'If you want to change this MV to a regular MV, please run with --full-refresh.'
+      ) %}
+    {% endif %}
+  {% else %}
+    {% if not existing_relation.is_refreshable %}
+      {% do exceptions.raise_compiler_error(
+        'Materialized view "' ~ mv_relation.name ~ '" is not refreshable, but the model defines a "refreshable" config. '
+        ~ 'A regular MV cannot be converted to a refreshable MV in place. '
+        ~ 'If you want to change this MV to be refreshable, please run with --full-refresh.'
+      ) %}
+    {% endif %}
+    {%- set config_append = true if (refreshable_config is mapping and refreshable_config.get('append', false)) else false -%}
+    {% if config_append != existing_relation.refreshable_append %}
+      {% do exceptions.raise_compiler_error(
+        'The APPEND setting of materialized view "' ~ mv_relation.name ~ '" does not match the model config. '
+        ~ 'APPEND cannot be changed via ALTER TABLE ... MODIFY REFRESH. '
+        ~ 'If you want to change it, please run with --full-refresh.'
+      ) %}
+    {% endif %}
+    {{ log('Updating refresh parameters of existing MV ' ~ mv_relation.name) }}
+    {%- set modify_refresh_clause = refreshable_mv_clause(with_append=false) -%}
+    {% call statement('modify refresh of existing mv: ' + mv_relation.name) -%}
+      alter table {{ mv_relation }} {{ cluster_clause }} modify {{ modify_refresh_clause }}
+    {%- endcall %}
+  {% endif %}
+{% endmacro %}
+
 {% macro clickhouse__update_mv(mv_relation, target_relation, cluster_clause, refreshable_clause, view_sql)  -%}
   {% set existing_relation = adapter.get_relation(database=mv_relation.database, schema=mv_relation.schema, identifier=mv_relation.identifier) %}
   {% if existing_relation %}
+    {{ clickhouse__modify_mv_refresh(mv_relation, existing_relation, cluster_clause) }}
     {{ clickhouse__modify_mv(mv_relation, cluster_clause, view_sql) }};
   {% else %}
     {{ clickhouse__drop_mv(mv_relation, cluster_clause) }};
@@ -447,7 +493,13 @@
   {{ clickhouse__create_mvs(target_relation, cluster_clause, refreshable_clause, views) }}
 {% endmacro %}
 
-{% macro refreshable_mv_clause() %}
+{#-
+  Renders the refresh clause of a refreshable MV (REFRESH ... [RANDOMIZE FOR ...]
+  [DEPENDS ON ...] [APPEND]). With with_append=false the APPEND keyword is omitted,
+  which makes the output usable in ALTER TABLE ... MODIFY REFRESH (that statement
+  replaces the whole schedule but cannot change APPEND mode).
+-#}
+{% macro refreshable_mv_clause(with_append=true) %}
   {%- if config.get('refreshable') is not none -%}
 
     {% set refreshable_config = config.get('refreshable') %}
@@ -510,7 +562,7 @@
       DEPENDS ON {{ depends_on_list | join(', ') }}
     {% endif %}
 
-    {%- if append -%}
+    {%- if append and with_append -%}
       APPEND
     {%- endif -%}
 

--- a/dbt/include/clickhouse/macros/materializations/materialized_view.sql
+++ b/dbt/include/clickhouse/macros/materializations/materialized_view.sql
@@ -343,46 +343,53 @@
 {#-
   Applies refresh parameter changes to an existing refreshable MV in place via
   ALTER TABLE ... MODIFY REFRESH (https://github.com/ClickHouse/dbt-clickhouse/issues/611).
-  Like MODIFY QUERY, the statement is issued on every run without diffing: it replaces the
-  whole schedule (interval, randomization and dependencies), so it is idempotent.
+  Like MODIFY QUERY, the statement is deliberately issued on every run without diffing
+  against the deployed schedule (simplicity over avoiding no-op DDL): it replaces the
+  whole schedule (interval, randomization and dependencies), so reissuing unchanged
+  parameters is a harmless no-op.
   The deployed state comes from the cached relation (is_refreshable / refreshable_append),
   so no extra round trip to ClickHouse is needed. Transitions that ClickHouse cannot apply
   in place (regular <-> refreshable, APPEND <-> non-APPEND) raise an error pointing the
   user to --full-refresh instead of being silently ignored.
+  mv_relation and existing_relation always refer to the same MV: both call sites resolve
+  existing_relation from mv_relation's own schema and identifier. The split exists because
+  mv_relation is the render target while existing_relation carries the cache-populated flags.
 -#}
 {% macro clickhouse__modify_mv_refresh(mv_relation, existing_relation, cluster_clause) %}
   {%- set refreshable_config = config.get('refreshable') -%}
-
-  {% if refreshable_config is none %}
-    {% if existing_relation.is_refreshable %}
+  {%- if refreshable_config is none or refreshable_config == false -%}
+    {%- if existing_relation.is_refreshable -%}
       {% do exceptions.raise_compiler_error(
         'Materialized view "' ~ mv_relation.name ~ '" is refreshable, but the model does not define a "refreshable" config. '
         ~ 'A refreshable MV cannot be converted to a regular MV in place. '
         ~ 'If you want to change this MV to a regular MV, please run with --full-refresh.'
       ) %}
-    {% endif %}
-  {% else %}
-    {% if not existing_relation.is_refreshable %}
+    {%- endif -%}
+  {%- else -%}
+    {%- if not existing_relation.is_refreshable -%}
       {% do exceptions.raise_compiler_error(
         'Materialized view "' ~ mv_relation.name ~ '" is not refreshable, but the model defines a "refreshable" config. '
         ~ 'A regular MV cannot be converted to a refreshable MV in place. '
         ~ 'If you want to change this MV to be refreshable, please run with --full-refresh.'
       ) %}
-    {% endif %}
+    {%- endif -%}
     {%- set config_append = true if (refreshable_config is mapping and refreshable_config.get('append', false)) else false -%}
-    {% if config_append != existing_relation.refreshable_append %}
+    {%- if config_append != existing_relation.refreshable_append -%}
       {% do exceptions.raise_compiler_error(
         'The APPEND setting of materialized view "' ~ mv_relation.name ~ '" does not match the model config. '
         ~ 'APPEND cannot be changed via ALTER TABLE ... MODIFY REFRESH. '
         ~ 'If you want to change it, please run with --full-refresh.'
       ) %}
-    {% endif %}
+    {%- endif -%}
     {{ log('Updating refresh parameters of existing MV ' ~ mv_relation.name) }}
-    {%- set modify_refresh_clause = refreshable_mv_clause(with_append=false) -%}
-    {% call statement('modify refresh of existing mv: ' + mv_relation.name) -%}
+    {#- ClickHouse requires the APPEND keyword in MODIFY REFRESH to match the view's
+        creation-time APPEND mode ("Adding or removing APPEND is not supported"), so the
+        full clause is used here; the guard above guarantees config and deployed agree. -#}
+    {%- set modify_refresh_clause = refreshable_mv_clause() -%}
+    {% call statement('modify refresh of existing mv: ' ~ mv_relation.name) -%}
       alter table {{ mv_relation }} {{ cluster_clause }} modify {{ modify_refresh_clause }}
     {%- endcall %}
-  {% endif %}
+  {%- endif -%}
 {% endmacro %}
 
 {% macro clickhouse__update_mv(mv_relation, target_relation, cluster_clause, refreshable_clause, view_sql)  -%}
@@ -494,13 +501,11 @@
 {% endmacro %}
 
 {#-
-  Renders the refresh clause of a refreshable MV (REFRESH ... [RANDOMIZE FOR ...]
-  [DEPENDS ON ...] [APPEND]). With with_append=false the APPEND keyword is omitted,
-  which makes the output usable in ALTER TABLE ... MODIFY REFRESH (that statement
-  replaces the whole schedule but cannot change APPEND mode).
+  Renders the refresh clause of a refreshable MV
+  (REFRESH ... [RANDOMIZE FOR ...] [DEPENDS ON ...] [APPEND]).
 -#}
-{% macro refreshable_mv_clause(with_append=true) %}
-  {%- if config.get('refreshable') is not none -%}
+{% macro refreshable_mv_clause() %}
+  {%- if config.get('refreshable') is not none and config.get('refreshable') != false -%}
 
     {% set refreshable_config = config.get('refreshable') %}
     {% if refreshable_config is not mapping %}
@@ -562,7 +567,7 @@
       DEPENDS ON {{ depends_on_list | join(', ') }}
     {% endif %}
 
-    {%- if append and with_append -%}
+    {%- if append -%}
       APPEND
     {%- endif -%}
 

--- a/tests/integration/adapter/materialized_view/test_refreshable_materialized_view.py
+++ b/tests/integration/adapter/materialized_view/test_refreshable_materialized_view.py
@@ -41,6 +41,100 @@ group by department
 """
 
 
+# Refresh parameters change between runs to test in-place updates via MODIFY REFRESH
+MV_REFRESH_UPDATE_MODEL = """
+{{ config(
+       materialized='materialized_view',
+       engine='MergeTree()',
+       order_by='(department)',
+       refreshable=(
+           {
+               "interval": "EVERY 5 MINUTE",
+               "randomize": "30 SECOND"
+           } if var('run_type', '') == 'update_refresh_params' else {
+               "interval": "EVERY 2 MINUTE"
+           }
+       )
+       )
+ }}
+select
+    department,
+    avg(age) as average
+    from {{ source('raw', 'people') }}
+group by department
+"""
+
+# Switches between a regular MV and a refreshable MV to test conversion handling
+PLAIN_TO_REFRESHABLE_MODEL = """
+{{ config(
+       materialized='materialized_view',
+       engine='MergeTree()',
+       order_by='(department)',
+       refreshable=(
+           {
+               "interval": "EVERY 2 MINUTE"
+           } if var('run_type', '') == 'make_refreshable' else none
+       )
+       )
+ }}
+select
+    department,
+    avg(age) as average
+    from {{ source('raw', 'people') }}
+group by department
+"""
+
+REFRESHABLE_TO_PLAIN_MODEL = """
+{{ config(
+       materialized='materialized_view',
+       engine='MergeTree()',
+       order_by='(department)',
+       refreshable=(
+           none if var('run_type', '') == 'make_regular' else {
+               "interval": "EVERY 2 MINUTE"
+           }
+       )
+       )
+ }}
+select
+    department,
+    avg(age) as average
+    from {{ source('raw', 'people') }}
+group by department
+"""
+
+# Toggles the APPEND setting, which cannot be changed via MODIFY REFRESH
+APPEND_TOGGLE_MODEL = """
+{{ config(
+       materialized='materialized_view',
+       engine='MergeTree()',
+       order_by='(department)',
+       refreshable=(
+           {
+               "interval": "EVERY 2 MINUTE"
+           } if var('run_type', '') == 'drop_append' else {
+               "interval": "EVERY 2 MINUTE",
+               "append": True
+           }
+       )
+       )
+ }}
+select
+    department,
+    avg(age) as average
+    from {{ source('raw', 'people') }}
+group by department
+"""
+
+
+def get_mv_ddl_and_uuid(project, mv_name):
+    return project.run_sql(
+        f"select create_table_query, uuid from system.tables"
+        f" where database = '{project.test_schema}' and name = '{mv_name}'",
+        fetch="one",
+    )
+
+
 class TestBasicRefreshableMV:
     @pytest.fixture(scope="class")
     def seeds(self):
@@ -126,3 +220,156 @@ class TestBasicRefreshableMV:
         result = run_dbt(["run", "--vars", json.dumps(run_vars)], False)
         assert result[0].status == 'error'
         assert 'No existing MV found matching MV' in result[0].message
+
+
+class TestModifyRefreshParamsMV:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "people.csv": PEOPLE_SEED_CSV,
+            "schema.yml": SEED_SCHEMA_YML,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "hackers.sql": MV_REFRESH_UPDATE_MODEL,
+        }
+
+    def test_update_refresh_params(self, project):
+        """
+        1. create a refreshable MV
+        2. re-run with changed refresh parameters (interval + randomize)
+        3. verify the new schedule was applied via MODIFY REFRESH, without recreating the MV
+        """
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+        results = run_dbt()
+        assert len(results) == 1
+
+        ddl, uuid_before = get_mv_ddl_and_uuid(project, 'hackers_mv')
+        assert 'REFRESH EVERY 2 MINUTE' in ddl
+
+        run_vars = {"run_type": "update_refresh_params"}
+        results = run_dbt(["run", "--vars", json.dumps(run_vars)])
+        assert len(results) == 1
+
+        ddl, uuid_after = get_mv_ddl_and_uuid(project, 'hackers_mv')
+        assert 'REFRESH EVERY 5 MINUTE' in ddl
+        assert 'RANDOMIZE FOR 30 SECOND' in ddl
+        # the MV was altered in place, not dropped and recreated
+        assert uuid_before == uuid_after
+
+
+class TestRegularToRefreshableMV:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "people.csv": PEOPLE_SEED_CSV,
+            "schema.yml": SEED_SCHEMA_YML,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "hackers.sql": PLAIN_TO_REFRESHABLE_MODEL,
+        }
+
+    def test_regular_to_refreshable_requires_full_refresh(self, project):
+        """
+        1. create a regular (non-refreshable) MV
+        2. re-run with a refreshable config and expect a clear error
+        3. re-run with --full-refresh and verify the MV is now refreshable
+        """
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+        results = run_dbt()
+        assert len(results) == 1
+
+        run_vars = json.dumps({"run_type": "make_refreshable"})
+        result = run_dbt(["run", "--vars", run_vars], False)
+        assert result[0].status == 'error'
+        assert 'is not refreshable' in result[0].message
+        assert '--full-refresh' in result[0].message
+
+        results = run_dbt(["run", "--full-refresh", "--vars", run_vars])
+        assert len(results) == 1
+        ddl, _ = get_mv_ddl_and_uuid(project, 'hackers_mv')
+        assert 'REFRESH EVERY 2 MINUTE' in ddl
+
+
+class TestRefreshableToRegularMV:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "people.csv": PEOPLE_SEED_CSV,
+            "schema.yml": SEED_SCHEMA_YML,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "hackers.sql": REFRESHABLE_TO_PLAIN_MODEL,
+        }
+
+    def test_refreshable_to_regular_requires_full_refresh(self, project):
+        """
+        1. create a refreshable MV
+        2. re-run without the refreshable config and expect a clear error
+        3. re-run with --full-refresh and verify the MV is now a regular MV
+        """
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+        results = run_dbt()
+        assert len(results) == 1
+
+        run_vars = json.dumps({"run_type": "make_regular"})
+        result = run_dbt(["run", "--vars", run_vars], False)
+        assert result[0].status == 'error'
+        assert 'is refreshable' in result[0].message
+        assert '--full-refresh' in result[0].message
+
+        results = run_dbt(["run", "--full-refresh", "--vars", run_vars])
+        assert len(results) == 1
+        ddl, _ = get_mv_ddl_and_uuid(project, 'hackers_mv')
+        assert ' REFRESH ' not in ddl
+
+
+class TestChangeAppendRefreshableMV:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "people.csv": PEOPLE_SEED_CSV,
+            "schema.yml": SEED_SCHEMA_YML,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "hackers.sql": APPEND_TOGGLE_MODEL,
+        }
+
+    def test_change_append_requires_full_refresh(self, project):
+        """
+        1. create a refreshable MV with APPEND
+        2. re-run without append and expect a clear error (APPEND can't be changed in place)
+        3. re-run with --full-refresh and verify the MV no longer has APPEND
+        """
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+        results = run_dbt()
+        assert len(results) == 1
+
+        ddl, _ = get_mv_ddl_and_uuid(project, 'hackers_mv')
+        assert ' APPEND ' in ddl
+
+        run_vars = json.dumps({"run_type": "drop_append"})
+        result = run_dbt(["run", "--vars", run_vars], False)
+        assert result[0].status == 'error'
+        assert 'APPEND' in result[0].message
+        assert '--full-refresh' in result[0].message
+
+        results = run_dbt(["run", "--full-refresh", "--vars", run_vars])
+        assert len(results) == 1
+        ddl, _ = get_mv_ddl_and_uuid(project, 'hackers_mv')
+        assert ' APPEND ' not in ddl

--- a/tests/integration/adapter/materialized_view/test_refreshable_materialized_view.py
+++ b/tests/integration/adapter/materialized_view/test_refreshable_materialized_view.py
@@ -103,6 +103,69 @@ select
 group by department
 """
 
+# An APPEND MV whose interval changes between runs; MODIFY REFRESH must keep APPEND
+APPEND_UPDATE_MODEL = """
+{{ config(
+       materialized='materialized_view',
+       engine='MergeTree()',
+       order_by='(department)',
+       refreshable=(
+           {
+               "interval": "EVERY 5 MINUTE",
+               "append": True
+           } if var('run_type', '') == 'update_refresh_params' else {
+               "interval": "EVERY 2 MINUTE",
+               "append": True
+           }
+       )
+       )
+ }}
+select
+    department,
+    avg(age) as average
+    from {{ source('raw', 'people') }}
+group by department
+"""
+
+# Adds APPEND to an existing non-APPEND refreshable MV, which cannot be done in place
+ADD_APPEND_MODEL = """
+{{ config(
+       materialized='materialized_view',
+       engine='MergeTree()',
+       order_by='(department)',
+       refreshable=(
+           {
+               "interval": "EVERY 2 MINUTE",
+               "append": True
+           } if var('run_type', '') == 'add_append' else {
+               "interval": "EVERY 2 MINUTE"
+           }
+       )
+       )
+ }}
+select
+    department,
+    avg(age) as average
+    from {{ source('raw', 'people') }}
+group by department
+"""
+
+# refreshable: false must behave exactly like omitting the config
+REFRESHABLE_FALSE_MODEL = """
+{{ config(
+       materialized='materialized_view',
+       engine='MergeTree()',
+       order_by='(department)',
+       refreshable=false
+       )
+ }}
+select
+    department,
+    avg(age) as average
+    from {{ source('raw', 'people') }}
+group by department
+"""
+
 # Toggles the APPEND setting, which cannot be changed via MODIFY REFRESH
 APPEND_TOGGLE_MODEL = """
 {{ config(
@@ -241,6 +304,7 @@ class TestModifyRefreshParamsMV:
         1. create a refreshable MV
         2. re-run with changed refresh parameters (interval + randomize)
         3. verify the new schedule was applied via MODIFY REFRESH, without recreating the MV
+        4. re-run with the same parameters and verify the no-op is harmless
         """
         results = run_dbt(["seed"])
         assert len(results) == 1
@@ -259,6 +323,13 @@ class TestModifyRefreshParamsMV:
         assert 'RANDOMIZE FOR 30 SECOND' in ddl
         # the MV was altered in place, not dropped and recreated
         assert uuid_before == uuid_after
+
+        # re-running with unchanged parameters reissues MODIFY REFRESH and is a no-op
+        results = run_dbt(["run", "--vars", json.dumps(run_vars)])
+        assert len(results) == 1
+        ddl, uuid_noop = get_mv_ddl_and_uuid(project, 'hackers_mv')
+        assert 'REFRESH EVERY 5 MINUTE' in ddl
+        assert uuid_noop == uuid_after
 
 
 class TestRegularToRefreshableMV:
@@ -373,3 +444,117 @@ class TestChangeAppendRefreshableMV:
         assert len(results) == 1
         ddl, _ = get_mv_ddl_and_uuid(project, 'hackers_mv')
         assert ' APPEND ' not in ddl
+
+
+class TestModifyRefreshParamsAppendMV:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "people.csv": PEOPLE_SEED_CSV,
+            "schema.yml": SEED_SCHEMA_YML,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "hackers.sql": APPEND_UPDATE_MODEL,
+        }
+
+    def test_update_refresh_params_append(self, project):
+        """
+        1. create a refreshable MV with APPEND
+        2. re-run with the same config and verify the no-op MODIFY REFRESH succeeds
+        3. re-run with a changed interval and verify it was applied, keeping APPEND
+        """
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+        results = run_dbt()
+        assert len(results) == 1
+
+        ddl, uuid_before = get_mv_ddl_and_uuid(project, 'hackers_mv')
+        assert 'REFRESH EVERY 2 MINUTE' in ddl
+        assert ' APPEND ' in ddl
+
+        # no-op re-run: MODIFY REFRESH must carry the APPEND keyword to be accepted
+        results = run_dbt()
+        assert len(results) == 1
+
+        run_vars = {"run_type": "update_refresh_params"}
+        results = run_dbt(["run", "--vars", json.dumps(run_vars)])
+        assert len(results) == 1
+
+        ddl, uuid_after = get_mv_ddl_and_uuid(project, 'hackers_mv')
+        assert 'REFRESH EVERY 5 MINUTE' in ddl
+        assert ' APPEND ' in ddl
+        assert uuid_before == uuid_after
+
+
+class TestAddAppendToRefreshableMV:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "people.csv": PEOPLE_SEED_CSV,
+            "schema.yml": SEED_SCHEMA_YML,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "hackers.sql": ADD_APPEND_MODEL,
+        }
+
+    def test_add_append_requires_full_refresh(self, project):
+        """
+        1. create a refreshable MV without APPEND
+        2. re-run with append=True and expect a clear error
+        3. re-run with --full-refresh and verify the MV now has APPEND
+        """
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+        results = run_dbt()
+        assert len(results) == 1
+
+        run_vars = json.dumps({"run_type": "add_append"})
+        result = run_dbt(["run", "--vars", run_vars], False)
+        assert result[0].status == 'error'
+        assert 'APPEND' in result[0].message
+        assert '--full-refresh' in result[0].message
+
+        results = run_dbt(["run", "--full-refresh", "--vars", run_vars])
+        assert len(results) == 1
+        ddl, _ = get_mv_ddl_and_uuid(project, 'hackers_mv')
+        assert ' APPEND ' in ddl
+
+
+class TestRefreshableFalseMV:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "people.csv": PEOPLE_SEED_CSV,
+            "schema.yml": SEED_SCHEMA_YML,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "hackers.sql": REFRESHABLE_FALSE_MODEL,
+        }
+
+    def test_refreshable_false_is_regular_mv(self, project):
+        """
+        refreshable: false must behave exactly like omitting the config:
+        the MV is created as a regular MV and can be updated in place
+        """
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+        results = run_dbt()
+        assert len(results) == 1
+
+        ddl, _ = get_mv_ddl_and_uuid(project, 'hackers_mv')
+        assert ' REFRESH ' not in ddl
+
+        # the update path must also treat refreshable: false as disabled
+        results = run_dbt()
+        assert len(results) == 1
+        ddl, _ = get_mv_ddl_and_uuid(project, 'hackers_mv')
+        assert ' REFRESH ' not in ddl

--- a/tests/integration/adapter/materialized_view/test_refreshable_materialized_view_external_target.py
+++ b/tests/integration/adapter/materialized_view/test_refreshable_materialized_view_external_target.py
@@ -145,3 +145,75 @@ class TestBasicExternalTargetRefreshableMV:
         error_results = [r for r in result if r.status == 'error']
         assert len(error_results) > 0
         assert 'No existing MV found matching MV' in error_results[0].message
+
+
+# Refresh parameters change between runs to test in-place updates via MODIFY REFRESH
+MV_REFRESH_UPDATE_MODEL = """
+{{ config(
+       materialized='materialized_view',
+       refreshable=(
+           {
+               "interval": "EVERY 5 MINUTE",
+               "randomize": "30 SECOND"
+           } if var('run_type', '') == 'update_refresh_params' else {
+               "interval": "EVERY 2 MINUTE"
+           }
+       )
+) }}
+
+{{ materialization_target_table(ref('hackers_target')) }}
+
+select
+    department,
+    avg(age) as average
+from {{ source('raw', 'people') }}
+group by department
+"""
+
+
+class TestModifyRefreshParamsExternalTargetMV:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "people.csv": PEOPLE_SEED_CSV,
+            "schema.yml": SEED_SCHEMA_YML,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "hackers_target.sql": TARGET_TABLE_MODEL,
+            "hackers.sql": MV_REFRESH_UPDATE_MODEL,
+        }
+
+    def test_update_refresh_params(self, project):
+        """
+        1. create a target table and a refreshable MV pointing to it
+        2. re-run with changed refresh parameters (interval + randomize)
+        3. verify the new schedule was applied via MODIFY REFRESH, without recreating the MV
+        """
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+        results = run_dbt()
+        assert len(results) == 2
+
+        ddl, uuid_before = project.run_sql(
+            f"select create_table_query, uuid from system.tables"
+            f" where database = '{project.test_schema}' and name = 'hackers'",
+            fetch="one",
+        )
+        assert 'REFRESH EVERY 2 MINUTE' in ddl
+
+        run_vars = {"run_type": "update_refresh_params"}
+        results = run_dbt(["run", "--vars", json.dumps(run_vars)])
+        assert len(results) == 2
+
+        ddl, uuid_after = project.run_sql(
+            f"select create_table_query, uuid from system.tables"
+            f" where database = '{project.test_schema}' and name = 'hackers'",
+            fetch="one",
+        )
+        assert 'REFRESH EVERY 5 MINUTE' in ddl
+        assert 'RANDOMIZE FOR 30 SECOND' in ddl
+        # the MV was altered in place, not dropped and recreated
+        assert uuid_before == uuid_after


### PR DESCRIPTION
## Summary

Closes #611

Until now, changing the refresh parameters of a refreshable MV (things like interval, randomize, depends_on) required a `--full-refresh` run, which drops and recreates the view. This PR applies them in place on every dbt run using `ALTER TABLE ... MODIFY REFRESH`, the same way we already update the query via `MODIFY QUERY` - no downtime, no unwanted refresh on recreate, and the view keeps its identity in `system.view_refreshes`.

Some transitions can't be done in place (without querying CH for additional metadata), and previously they were silently ignored. They now fail with an error pointing the user to `--full-refresh`:

- turning an existing regular MV into a refreshable one (or the other way around)
- changing the append setting

To detect these cases without extra queries, the deployed state (`is_refreshable`, `refreshable_append`) is parsed from the DDL we already fetch in `list_relations_without_caching` and carried on the cached relation.

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
