### PR TITLE
Test against dbt-core 1.12, widen dbt-adapters upper bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Release [1.10.3], 2026-XX-XX
 
 #### Improvements
-* Test against `dbt-core` 1.12 and widen the `dbt-adapters` upper bound to `<2.0` ([#718](https://github.com/ClickHouse/dbt-clickhouse/pull/718)).
+* Test against `dbt-core` 1.12 and widen the `dbt-adapters` upper bound to `<1.25.0` ([#718](https://github.com/ClickHouse/dbt-clickhouse/pull/718)).
 
 ### Release [1.10.2], 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Release [1.10.3], 2026-XX-XX
 
 #### Improvements
-* Test against `dbt-core` 1.12 and widen the `dbt-adapters` upper bound to `<2.0` ([#665](https://github.com/ClickHouse/dbt-clickhouse/issues/665)).
+* Test against `dbt-core` 1.12 and widen the `dbt-adapters` upper bound to `<2.0` ([#718](https://github.com/ClickHouse/dbt-clickhouse/pull/718)).
 
 ### Release [1.10.2], 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Release [1.10.3], 2026-XX-XX
+
+#### Improvements
+* Test against `dbt-core` 1.12 and widen the `dbt-adapters` upper bound to `<2.0` ([#665](https://github.com/ClickHouse/dbt-clickhouse/issues/665)).
+
 ### Release [1.10.2], 2026-08-13
 
 #### Improvements

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-dbt-core==1.11.*
+dbt-core==1.12.*
 dbt-tests-adapter>=1.10,<2.0
 pytest>=7.2.0
 pytest-dotenv==0.5.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "dbt-core>=1.9",
-    "dbt-adapters>=1.22.0,<2.0",
+    "dbt-adapters>=1.22.0,<1.25.0",  # This version should be dbt-adapters<2.0, but keeping it fixed for now to avoid unexpected issues. We need to frequently update it.
     "clickhouse-connect>=0.10.0",
     "clickhouse-driver>=0.2.10"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "dbt-core>=1.9",
-    "dbt-adapters>=1.22.0,<1.23.0",  # This version should be dbt-adapters<2.0, but keeping it fixed for now to avoid unexpected issues. We need to frequently update it.
+    "dbt-adapters>=1.22.0,<2.0",
     "clickhouse-connect>=0.10.0",
     "clickhouse-driver>=0.2.10"
 ]

--- a/tests/integration/adapter/concurrency/test_concurrency.py
+++ b/tests/integration/adapter/concurrency/test_concurrency.py
@@ -30,4 +30,4 @@ class TestConcurrency(BaseConcurrency):
         check_relations_equal(project.adapter, ["seed", "table_b"])
         check_table_does_not_exist(project.adapter, "invalid")
         check_table_does_not_exist(project.adapter, "skip")
-        assert "PASS=5 WARN=0 ERROR=1 SKIP=1 NO-OP=0 TOTAL=7" in output
+        assert "PASS=5 WARN=0 ERROR=1 SKIP=1 NO-OP=0 REUSED=0 TOTAL=7" in output


### PR DESCRIPTION
## Summary

Resolves #665. `dbt-core` reached GA on the 1.12 line; this widens
`dbt-adapters` from `<1.23.0` to `<2.0` (per the existing comment's own
stated direction) and points local/dev testing at `dbt-core==1.12.*`.

## Changes

* `pyproject.toml`: `dbt-adapters>=1.22.0,<1.23.0` → `>=1.22.0,<2.0`.
* `dev_requirements.txt`: `dbt-core==1.11.*` → `dbt-core==1.12.*`.
* `tests/integration/adapter/concurrency/test_concurrency.py`: fixed a
  test that hardcoded dbt's old run-summary string. `dbt-core` 1.12
  added a `REUSED` counter to that line (`... NO-OP=0 REUSED=0
  TOTAL=7`), so the assertion was stale and failed under 1.12. This is
  the only failure the version bump surfaced.
* `CHANGELOG.md`: new entry.

## Validation

Ran the full local suite (`pytest tests`, HTTP driver, against the
Docker-managed 3-node cluster from `tests/integration/docker-compose.yml`,
ClickHouse `latest`) on Python 3.12 with `dbt-core==1.12.2` (GA) +
`dbt-adapters==1.24.5` (the top of the now-widened range):

```
362 passed, 4 skipped, 1 xpassed, 0 failed
```

`make lint` (ruff format/check, mypy, yamllint) is clean, and
`pytest tests/unit` (88 tests) passes.

I additionally smoke-tested the same `dbt-core==1.12.2` /
`dbt-adapters==1.24.5` combination on **Python 3.14** (`dbt debug`,
`dbt test`, and `dbt run-operation`) — plugin load, connection,
compilation, macro dispatch, and execution all worked. I haven't
touched the CI Python-version matrix for 3.14 since dbt's own
documented compatibility page doesn't list it yet; happy to add it in
a follow-up if that's wanted.

I did not run the ClickHouse Cloud-specific suite (`test_cloud.yml`)
locally since it needs credentials I don't have — that'll need to run
in this repo's own CI.

## Notes

Have not signed the CLA yet if this is required for a first
contribution — will do so when prompted.