### PR TITLE
Parallelize test execution using xdist

### DIFF
--- a/.github/workflows/steps_local_testing.yml
+++ b/.github/workflows/steps_local_testing.yml
@@ -64,7 +64,7 @@ jobs:
           DBT_CH_TEST_CLUSTER: test_shard
         run: |
           PYTHONPATH="${PYTHONPATH}:dbt"
-          pytest tests -n 4 --dist loadscope --timeout=300
+          pytest tests -n 5 --dist loadscope --timeout=300
 
       - name: Run Native tests
         env:
@@ -72,4 +72,4 @@ jobs:
           DBT_CH_TEST_CLUSTER: test_shard
         run: |
           PYTHONPATH="${PYTHONPATH}:dbt"
-          pytest tests -n 4 --dist loadscope --timeout=300
+          pytest tests -n 5 --dist loadscope --timeout=300

--- a/.github/workflows/steps_local_testing.yml
+++ b/.github/workflows/steps_local_testing.yml
@@ -55,12 +55,16 @@ jobs:
       - name: Install requirements
         run: pip3 install . -r dev_requirements.txt
 
+      # -n 4 --dist loadscope: run test classes concurrently on 4 xdist workers.
+      # loadscope is required — the project/schema fixtures are class-scoped.
+      # The per-test timeout is higher than in sequential runs because tests slow
+      # down under the extra load on the shared runner.
       - name: Run HTTP tests
         env:
           DBT_CH_TEST_CLUSTER: test_shard
         run: |
           PYTHONPATH="${PYTHONPATH}:dbt"
-          pytest tests --timeout=120
+          pytest tests -n 4 --dist loadscope --timeout=300
 
       - name: Run Native tests
         env:
@@ -68,4 +72,4 @@ jobs:
           DBT_CH_TEST_CLUSTER: test_shard
         run: |
           PYTHONPATH="${PYTHONPATH}:dbt"
-          pytest tests --timeout=120
+          pytest tests -n 4 --dist loadscope --timeout=300

--- a/.github/workflows/test_cloud.yml
+++ b/.github/workflows/test_cloud.yml
@@ -33,12 +33,14 @@ jobs:
       - name: Install requirements
         run: pip3 install . -r dev_requirements.txt
 
+      # -n 4 --dist loadscope: run test classes concurrently on 4 xdist workers
+      # (loadscope is required — the project/schema fixtures are class-scoped).
       - name: Run HTTP tests
         env:
           DBT_CH_TEST_PORT: 8443
-        run: pytest tests
+        run: pytest tests -n 4 --dist loadscope --timeout=300
 
       - name: Run Native tests
         env:
           DBT_CH_TEST_PORT: 9440
-        run: pytest tests
+        run: pytest tests -n 4 --dist loadscope --timeout=300

--- a/.github/workflows/test_cloud.yml
+++ b/.github/workflows/test_cloud.yml
@@ -33,14 +33,14 @@ jobs:
       - name: Install requirements
         run: pip3 install . -r dev_requirements.txt
 
-      # -n 3 --dist loadscope: run test classes concurrently on 3 xdist workers
+      # -n 1 --dist loadscope: run test classes concurrently on 3 xdist workers
       # (loadscope is required — the project/schema fixtures are class-scoped).
       - name: Run HTTP tests
         env:
           DBT_CH_TEST_PORT: 8443
-        run: pytest tests -n 3 --dist loadscope --timeout=300
+        run: pytest tests -n 1 --dist loadscope --timeout=300
 
       - name: Run Native tests
         env:
           DBT_CH_TEST_PORT: 9440
-        run: pytest tests -n 3 --dist loadscope --timeout=300
+        run: pytest tests -n 1 --dist loadscope --timeout=300

--- a/.github/workflows/test_cloud.yml
+++ b/.github/workflows/test_cloud.yml
@@ -33,14 +33,14 @@ jobs:
       - name: Install requirements
         run: pip3 install . -r dev_requirements.txt
 
-      # -n 4 --dist loadscope: run test classes concurrently on 4 xdist workers
+      # -n 3 --dist loadscope: run test classes concurrently on 3 xdist workers
       # (loadscope is required — the project/schema fixtures are class-scoped).
       - name: Run HTTP tests
         env:
           DBT_CH_TEST_PORT: 8443
-        run: pytest tests -n 5 --dist loadscope --timeout=300
+        run: pytest tests -n 3 --dist loadscope --timeout=300
 
       - name: Run Native tests
         env:
           DBT_CH_TEST_PORT: 9440
-        run: pytest tests -n 5 --dist loadscope --timeout=300
+        run: pytest tests -n 3 --dist loadscope --timeout=300

--- a/.github/workflows/test_cloud.yml
+++ b/.github/workflows/test_cloud.yml
@@ -38,9 +38,9 @@ jobs:
       - name: Run HTTP tests
         env:
           DBT_CH_TEST_PORT: 8443
-        run: pytest tests -n 4 --dist loadscope --timeout=300
+        run: pytest tests -n 5 --dist loadscope --timeout=300
 
       - name: Run Native tests
         env:
           DBT_CH_TEST_PORT: 9440
-        run: pytest tests -n 4 --dist loadscope --timeout=300
+        run: pytest tests -n 5 --dist loadscope --timeout=300

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,16 +96,24 @@ Use `pytest tests` to run tests.
 
 There are two ways to run the integration tests:
 
-* **Sequential (default):** plain `pytest tests`. With `DBT_CH_TEST_USE_DOCKER=True` the test session
-  starts and stops the ClickHouse cluster from
-  [tests/integration/docker-compose.yml](./tests/integration/docker-compose.yml) for you.
-* **Parallel:** `pytest tests -n 4 --dist loadscope` (requires `pytest-xdist`, part of
-  `dev_requirements.txt`; `--dist loadscope` is required because the project/schema fixtures are
-  class-scoped). In this mode the ClickHouse cluster must be **started externally before the run**
-  (e.g. `docker compose -f tests/integration/docker-compose.yml up -d`) and
-  `DBT_CH_TEST_USE_DOCKER` must stay unset — each xdist worker would otherwise restart the cluster
-  underneath the others, and the tests will refuse the combination. This is how the GitHub Actions
-  workflows run.
+**Sequential (default):**  
+```shell
+# If you add DBT_CH_TEST_USE_DOCKER=True, as an environment variable or in the test.env file, pytest will automatically start and stop the ClickHouse cluster from tests/integration/docker-compose.yml for you.
+pytest tests
+```
+**Parallel:** 
+This method is incompatible with `DBT_CH_TEST_USE_DOCKER=True`. You need to start and stop the Docker container yourself. You can use the tests docker compose file to start the ClickHouse cluster:
+
+```shell
+docker compose -f tests/integration/docker-compose.yml up -d
+```
+
+And then:
+```shell
+pytest tests -n 10 --dist loadscope
+```
+
+#### Test configuration
 
 You can customize the test environment via environment variables. We recommend doing so with the pytest `pytest-dotenv` plugin combined with root level `test.env`
 configuration file (this file should not be checked into git).  The following environment variables are recognized:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,19 @@ Add a user-facing entry to the unreleased section at the top of [CHANGELOG.md](C
 This adapter passes all of dbt basic tests as presented in dbt's [official docs](https://docs.getdbt.com/docs/contributing/testing-a-new-adapter#testing-your-adapter).
 Use `pytest tests` to run tests.
 
+There are two ways to run the integration tests:
+
+* **Sequential (default):** plain `pytest tests`. With `DBT_CH_TEST_USE_DOCKER=True` the test session
+  starts and stops the ClickHouse cluster from
+  [tests/integration/docker-compose.yml](./tests/integration/docker-compose.yml) for you.
+* **Parallel:** `pytest tests -n 4 --dist loadscope` (requires `pytest-xdist`, part of
+  `dev_requirements.txt`; `--dist loadscope` is required because the project/schema fixtures are
+  class-scoped). In this mode the ClickHouse cluster must be **started externally before the run**
+  (e.g. `docker compose -f tests/integration/docker-compose.yml up -d`) and
+  `DBT_CH_TEST_USE_DOCKER` must stay unset — each xdist worker would otherwise restart the cluster
+  underneath the others, and the tests will refuse the combination. This is how the GitHub Actions
+  workflows run.
+
 You can customize the test environment via environment variables. We recommend doing so with the pytest `pytest-dotenv` plugin combined with root level `test.env`
 configuration file (this file should not be checked into git).  The following environment variables are recognized:
 
@@ -111,7 +124,7 @@ configuration file (this file should not be checked into git).  The following en
 
 ### Example Configurations
 
-Local development using the docker compose file included (cluster start/stop will be managed by the tests)
+Local development using the docker compose file included (cluster start/stop will be managed by the tests; sequential runs only, see above)
 
 ```env
 DBT_CH_TEST_USE_DOCKER=True

--- a/dbt/adapters/clickhouse/dbclient.py
+++ b/dbt/adapters/clickhouse/dbclient.py
@@ -11,7 +11,7 @@ from dbt.adapters.clickhouse.errors import (
 )
 from dbt.adapters.clickhouse.logger import logger
 from dbt.adapters.clickhouse.query import quote_identifier
-from dbt.adapters.clickhouse.util import engine_can_atomic_exchange
+from dbt.adapters.clickhouse.util import engine_can_atomic_exchange, retry_on_database_error
 from dbt.adapters.exceptions import FailedToConnectError
 from dbt_common.exceptions import DbtConfigError, DbtDatabaseError
 
@@ -130,8 +130,30 @@ class ChClientWrapper(ABC):
     def query(self, sql: str, **kwargs):
         pass
 
+    def command(self, sql: str, retries: int = 1, **kwargs):
+        """Run a ClickHouse statement. Pass `retries` > 1 to retry transient
+        failures — only safe for idempotent statements."""
+        return retry_on_database_error(
+            lambda: self._command(sql, **kwargs), 'ClickHouse command', retries
+        )
+
+    def get_ch_setting(self, setting_name, retries: int = 3):
+        """Return (value, readonly) for a server setting, retrying transient
+        failures; (None, 0) when the setting could not be read."""
+        try:
+            return retry_on_database_error(
+                lambda: self._get_ch_setting(setting_name),
+                f'Reading ClickHouse setting {setting_name}',
+                retries,
+            )
+        except DbtDatabaseError as ex:
+            logger.warning(
+                f'Failed to read ClickHouse setting {setting_name} after {retries} attempts: {ex}'
+            )
+            return (None, 0)
+
     @abstractmethod
-    def command(self, sql: str, **kwargs):
+    def _command(self, sql: str, **kwargs):
         pass
 
     @abstractmethod
@@ -139,7 +161,7 @@ class ChClientWrapper(ABC):
         pass
 
     @abstractmethod
-    def get_ch_setting(self, setting_name):
+    def _get_ch_setting(self, setting_name):
         pass
 
     def database_dropped(self, database: str):
@@ -179,12 +201,25 @@ class ChClientWrapper(ABC):
         # checked (and enabled when the user has permission to change it).
         global _nd_mutation_probe
         with _nd_mutation_lock:
-            if _nd_mutation_probe is None:
-                _nd_mutation_probe = self.get_ch_setting(ND_MUTATION_SETTING)
-            nd_mutations, nd_mutations_read_only = _nd_mutation_probe
+            probe = _nd_mutation_probe
+            if probe is None:
+                probe = self.get_ch_setting(ND_MUTATION_SETTING)
+                if probe[0] is not None:
+                    _nd_mutation_probe = probe
+                else:
+                    # Failed probe: leave the cache empty so the next connection
+                    # probes again instead of poisoning the whole process.
+                    logger.warning(
+                        f'Could not read the {ND_MUTATION_SETTING} setting from the server; '
+                        f'lightweight deletes are disabled for this connection only'
+                    )
+            nd_mutations, nd_mutations_read_only = probe
         if nd_mutations is None:
             if requested:
-                logger.warning(nd_mutations_not_enabled_warning)
+                logger.warning(
+                    f'The {ND_MUTATION_SETTING} setting could not be determined, so lightweight '
+                    f'deletes and the delete+insert incremental strategy are disabled'
+                )
             return False, False
         nd_mutations = int(nd_mutations) > 0
         if not nd_mutations:
@@ -194,12 +229,19 @@ class ChClientWrapper(ABC):
                     raise DbtConfigError(nd_mutations_not_enabled_error)
                 logger.warning(nd_mutations_not_enabled_warning)
             else:
+                # A failure here silently downgrades the connection to the legacy
+                # incremental strategy, so command() retries transient errors and
+                # the final error is logged for diagnosis.
                 try:
-                    self.command(f'SET {ND_MUTATION_SETTING} = 1')
+                    self.command(f'SET {ND_MUTATION_SETTING} = 1', retries=3)
                     self._conn_settings[ND_MUTATION_SETTING] = '1'
                     nd_mutations = True
-                except DbtDatabaseError:
-                    logger.warning(nd_mutations_not_enabled_warning)
+                except DbtDatabaseError as ex:
+                    logger.warning(
+                        f'Could not enable {ND_MUTATION_SETTING} for this connection, so '
+                        f'lightweight deletes and the delete+insert incremental strategy '
+                        f'are disabled: {ex}'
+                    )
         if nd_mutations:
             return True, requested
         return False, False

--- a/dbt/adapters/clickhouse/httpclient.py
+++ b/dbt/adapters/clickhouse/httpclient.py
@@ -28,7 +28,7 @@ class ChHttpClient(ChClientWrapper):
             err_msg = hide_stack_trace(ex)
             raise DbtDatabaseError(err_msg) from ex
 
-    def command(self, sql, **kwargs):
+    def _command(self, sql, **kwargs):
         try:
             self._inject_query_id(kwargs)
             return self._client.command(sql, **kwargs)
@@ -52,7 +52,7 @@ class ChHttpClient(ChClientWrapper):
             err_msg = hide_stack_trace(ex)
             raise DbtDatabaseError(err_msg) from ex
 
-    def get_ch_setting(self, setting_name):
+    def _get_ch_setting(self, setting_name):
         setting = self._client.server_settings.get(setting_name)
         return (setting.value, setting.readonly) if setting else (None, 0)
 

--- a/dbt/adapters/clickhouse/nativeclient.py
+++ b/dbt/adapters/clickhouse/nativeclient.py
@@ -7,7 +7,6 @@ from dbt.adapters.__about__ import version as dbt_adapters_version
 from dbt.adapters.clickhouse import ClickHouseColumn, ClickHouseCredentials
 from dbt.adapters.clickhouse.__version__ import version as dbt_clickhouse_version
 from dbt.adapters.clickhouse.dbclient import ChClientWrapper, ChRetryableException
-from dbt.adapters.clickhouse.logger import logger
 from dbt.adapters.clickhouse.util import hide_stack_trace
 from dbt_common.exceptions import DbtDatabaseError
 
@@ -25,7 +24,7 @@ class ChNativeClient(ChClientWrapper):
             err_msg = hide_stack_trace(ex)
             raise DbtDatabaseError(err_msg) from ex
 
-    def command(self, sql, **kwargs):
+    def _command(self, sql, **kwargs):
         try:
             result = self._client.execute(sql, **kwargs)
             if len(result) and len(result[0]):
@@ -46,14 +45,14 @@ class ChNativeClient(ChClientWrapper):
             err_msg = hide_stack_trace(ex)
             raise DbtDatabaseError(err_msg) from ex
 
-    def get_ch_setting(self, setting_name):
+    def _get_ch_setting(self, setting_name):
         try:
             result = self._client.execute(
                 f"SELECT value, readonly FROM system.settings WHERE name = '{setting_name}'"
             )
         except clickhouse_driver.errors.Error as ex:
-            logger.warn('Unexpected error retrieving ClickHouse server setting', ex)
-            return None
+            err_msg = hide_stack_trace(ex)
+            raise DbtDatabaseError(err_msg) from ex
         return (result[0][0], result[0][1]) if result else (None, 0)
 
     def close(self):

--- a/dbt/adapters/clickhouse/util.py
+++ b/dbt/adapters/clickhouse/util.py
@@ -1,6 +1,30 @@
 import os
+import time
+from typing import Callable, TypeVar
 
-from dbt_common.exceptions import DbtRuntimeError
+from dbt.adapters.clickhouse.logger import logger
+from dbt_common.exceptions import DbtDatabaseError, DbtRuntimeError
+
+T = TypeVar('T')
+
+
+def retry_on_database_error(
+    fn: Callable[[], T], description: str, attempts: int, delay: float = 0.5
+) -> T:
+    """Call `fn`, retrying up to `attempts` total tries when it raises
+    DbtDatabaseError, sleeping `delay` seconds between tries. Retried failures
+    are logged with `description`; the exception from the final attempt
+    propagates to the caller. Only use for idempotent operations."""
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            return fn()
+        except DbtDatabaseError as ex:
+            if attempt >= attempts:
+                raise
+            logger.warning(f'{description} failed (attempt {attempt}/{attempts}), retrying: {ex}')
+            time.sleep(delay)
 
 
 def compare_versions(v1: str, v2: str) -> int:

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,6 +3,7 @@ dbt-tests-adapter>=1.10,<2.0
 pytest>=7.2.0
 pytest-dotenv==0.5.2
 pytest-timeout==2.4.0
+pytest-xdist==3.8.0
 ruff==0.16.0
 mypy==1.19.1
 yamllint==1.37.1

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,10 @@ filterwarnings =
 env_files =
     test.env
 pythonpath = .
+# name per convention
 testpaths =
-    tests/integration  # name per convention
-addopts = --doctest-modules
+    tests/integration
+# --ignore-glob: --doctest-modules would otherwise import every conftest.py as a
+# plain module named `conftest`, which collides once two directories have one.
+# Conftest loading for fixtures is a separate mechanism and is not affected.
+addopts = --doctest-modules --ignore-glob=**/conftest.py

--- a/tests/integration/adapter/clickhouse/test_clickhouse_errors.py
+++ b/tests/integration/adapter/clickhouse/test_clickhouse_errors.py
@@ -2,7 +2,7 @@ import pytest
 from dbt.tests.util import run_dbt
 
 oom_table_sql = """
-SELECT a FROM system.numbers_mt GROUP BY repeat(toString(number), 100000) as a
+select sum(number) as a from system.numbers limit 1000 SETTINGS max_memory_usage = 1
 """
 
 schema_yaml = """

--- a/tests/integration/adapter/dbt_clone/conftest.py
+++ b/tests/integration/adapter/dbt_clone/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+# The upstream dbt_clone fixtures grant to "{{ env_var('DBT_TEST_USER_1') }}" at
+# parse time; requesting ch_test_users here creates per-class users and exports
+# the DBT_TEST_USER_1..3 variables before any test in this package runs dbt.
+@pytest.fixture(scope="class", autouse=True)
+def ensure_ch_test_users(ch_test_users):
+    pass

--- a/tests/integration/adapter/grants/conftest.py
+++ b/tests/integration/adapter/grants/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+
+# The upstream grants base classes read DBT_TEST_USER_1..3 from the environment:
+# BaseGrants.get_test_users at class setup, and the model/schema fixtures via
+# env_var() at parse time. Requesting ch_test_users here creates per-class users
+# and exports those variables first — conftest-level autouse fixtures are ordered
+# before same-scope autouse fixtures defined on the test classes, so this resolves
+# ahead of BaseGrants.get_test_users.
+@pytest.fixture(scope="class", autouse=True)
+def ensure_ch_test_users(ch_test_users):
+    pass

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -78,14 +78,17 @@ def ch_test_users(test_config):
             os.environ[key] = dbt_user
         yield test_users
     finally:
-        for dbt_user in test_users:
-            test_client.command(f'DROP USER IF EXISTS %s {cluster_clause}', (dbt_user,))
-        test_client.close()
+        # Restore the environment first: it cannot fail, unlike the DROPs below
         for key, value in saved_env.items():
             if value is None:
                 os.environ.pop(key, None)
             else:
                 os.environ[key] = value
+        try:
+            for dbt_user in test_users:
+                test_client.command(f'DROP USER IF EXISTS %s {cluster_clause}', (dbt_user,))
+        finally:
+            test_client.close()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,4 @@
 import os
-import random
 import sys
 import time
 import timeit
@@ -12,18 +11,81 @@ import requests
 from clickhouse_connect import get_client
 
 
-# Ensure that test users exist in environment
-@pytest.fixture(scope="session", autouse=True)
-def ch_test_users():
+def _connection_settings():
+    """Resolve the ClickHouse connection settings shared by the test_config and
+    ch_test_users fixtures. Everything derives from the environment, so every
+    xdist worker resolves the same values."""
+    test_port = int(os.environ.get('DBT_CH_TEST_PORT', 8123))
+    client_port = int(os.environ.get('DBT_CH_TEST_CLIENT_PORT', 0))
+    test_driver = os.environ.get('DBT_CH_TEST_DRIVER', '').lower()
+    if test_driver == '':
+        test_driver = 'native' if test_port in (10900, 9000, 9440) else 'http'
+    test_secure = test_port in (8443, 9440)
+    docker = os.environ.get('DBT_CH_TEST_USE_DOCKER', '').lower() in ('1', 'true', 'yes')
+    if docker:
+        client_port = client_port or 10723
+        test_port = 10900 if test_driver == 'native' else client_port
+    elif not client_port:
+        if test_driver == 'native':
+            client_port = 8443 if test_port == 9440 else 8123
+        else:
+            client_port = test_port
+    return {
+        'host': os.environ.get('DBT_CH_TEST_HOST', 'localhost'),
+        'port': test_port,
+        'client_port': client_port,
+        'driver': test_driver,
+        'user': os.environ.get('DBT_CH_TEST_USER', 'default'),
+        'password': os.environ.get('DBT_CH_TEST_PASSWORD', ''),
+        'cluster': os.environ.get('DBT_CH_TEST_CLUSTER', ''),
+        'secure': test_secure,
+        'docker': docker,
+    }
 
-    def generate_random_string():
-        return str(uuid.uuid4()).replace('-', '')[:10]
 
-    test_users = [
-        os.environ.setdefault(f'DBT_TEST_USER_{x}', f'dbt_test_user_{generate_random_string()}')
-        for x in range(1, 4)
-    ]
-    yield test_users
+def _get_test_client(conn):
+    return get_client(
+        host=conn['host'],
+        port=conn['client_port'],
+        username=conn['user'],
+        password=conn['password'],
+        secure=conn['secure'],
+    )
+
+
+# Creates the DBT_TEST_USER_1..3 ClickHouse users for the requesting test class
+# and exports their names to the environment, where the grants/dbt_clone tests
+# read them back via env_var()/os.getenv. Class-scoped rather than session-scoped
+# on purpose: creation and consumption happen in the same process, so under
+# pytest-xdist no state has to cross worker boundaries. Only the test packages
+# that need the users request this fixture (via autouse fixtures in their
+# conftest.py); everything else never pays for it.
+@pytest.fixture(scope="class")
+def ch_test_users(test_config):
+    env_keys = [f'DBT_TEST_USER_{x}' for x in range(1, 4)]
+    saved_env = {key: os.environ.get(key) for key in env_keys}
+    # Unique per class so concurrent xdist workers never collide on CREATE/DROP
+    test_users = [f'dbt_test_user_{uuid.uuid4().hex[:10]}' for _ in env_keys]
+    cluster = test_config['cluster']
+    cluster_clause = f'ON CLUSTER "{cluster}"' if cluster else ''
+    test_client = _get_test_client(test_config)
+    try:
+        for key, dbt_user in zip(env_keys, test_users, strict=True):
+            test_client.command(
+                f'CREATE USER IF NOT EXISTS %s {cluster_clause} IDENTIFIED WITH sha256_hash BY %s',
+                (dbt_user, '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8'),
+            )
+            os.environ[key] = dbt_user
+        yield test_users
+    finally:
+        for dbt_user in test_users:
+            test_client.command(f'DROP USER IF EXISTS %s {cluster_clause}', (dbt_user,))
+        test_client.close()
+        for key, value in saved_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -32,89 +94,68 @@ def ch_test_version():
 
 
 # This fixture is for customizing tests that need overrides in adapter
-# repos. Example in dbt.tests.adapter.basic.test_base.
+# repos. Example in dbt.tests.adapter.basic.test_base. It also owns the
+# docker compose lifecycle when DBT_CH_TEST_USE_DOCKER is set — a sequential-only
+# convenience: under pytest-xdist this session fixture runs once per WORKER, and
+# concurrent workers would start/stop the cluster underneath each other, so that
+# combination is rejected. For parallel runs, start the cluster externally
+# (as the GitHub Actions workflows do) and leave DBT_CH_TEST_USE_DOCKER unset.
 @pytest.fixture(scope="session")
-def test_config(ch_test_users, ch_test_version):
-    compose_file = f'{Path(__file__).parent}/docker-compose.yml'
-    test_host = os.environ.get('DBT_CH_TEST_HOST', 'localhost')
-    test_port = int(os.environ.get('DBT_CH_TEST_PORT', 8123))
-    client_port = int(os.environ.get('DBT_CH_TEST_CLIENT_PORT', 0))
-    test_driver = os.environ.get('DBT_CH_TEST_DRIVER', '').lower()
-    if test_driver == '':
-        test_driver = 'native' if test_port in (10900, 9000, 9440) else 'http'
-    test_user = os.environ.get('DBT_CH_TEST_USER', 'default')
-    test_password = os.environ.get('DBT_CH_TEST_PASSWORD', '')
-    test_cluster = os.environ.get('DBT_CH_TEST_CLUSTER', '')
+def test_config(ch_test_version):
+    conn = _connection_settings()
     test_cloud = os.environ.get('DBT_CH_TEST_CLOUD', '').lower() in ('1', 'true', 'yes')
-    test_db_engine = os.environ.get('DBT_CH_TEST_DB_ENGINE', 'Shared' if test_cloud else '')
-    test_secure = test_port in (8443, 9440)
-    test_cluster_mode = os.environ.get('DBT_CH_TEST_CLUSTER_MODE', '').lower() in (
-        '1',
-        'true',
-        'yes',
-    )
     if ch_test_version.startswith('22.3'):
         os.environ['DBT_CH_TEST_SETTINGS'] = '22_3'
 
-    docker = os.environ.get('DBT_CH_TEST_USE_DOCKER', '').lower() in ('1', 'true', 'yes')
-
-    if docker:
-        client_port = client_port or 10723
-        test_port = 10900 if test_driver == 'native' else client_port
+    compose_file = f'{Path(__file__).parent}/docker-compose.yml'
+    docker_started = False
+    if conn['docker']:
+        if os.environ.get('PYTEST_XDIST_WORKER'):
+            raise Exception(
+                'DBT_CH_TEST_USE_DOCKER is incompatible with pytest-xdist (-n): each '
+                'worker would manage the compose cluster underneath the others. For '
+                'parallel runs start it yourself first, e.g. '
+                '`docker compose -f tests/integration/docker-compose.yml up -d`, '
+                'and unset DBT_CH_TEST_USE_DOCKER.'
+            )
+        run_cmd(['docker', 'compose', '-f', compose_file, 'down', '-v'])
+        sys.stderr.write('Starting docker compose')
+        os.environ['PROJECT_ROOT'] = '.'
         try:
-            run_cmd(['docker', 'compose', '-f', compose_file, 'down', '-v'])
-            sys.stderr.write('Starting docker compose')
-            os.environ['PROJECT_ROOT'] = '.'
             up_result = run_cmd(['docker', 'compose', '-f', compose_file, 'up', '-d'])
             if up_result[0]:
                 raise Exception(f'Failed to start docker: {up_result[2]}')
-            url = f"http://{test_host}:{client_port}"
+            url = f"http://{conn['host']}:{conn['client_port']}"
             wait_until_responsive(timeout=30.0, pause=0.5, check=lambda: is_responsive(url))
-        except Exception as e:
-            raise Exception('Failed to run docker compose: {}', str(e)) from e
-    elif not client_port:
-        if test_driver == 'native':
-            client_port = 8443 if test_port == 9440 else 8123
-        else:
-            client_port = test_port
+            docker_started = True
+        except Exception:
+            run_cmd(['docker', 'compose', '-f', compose_file, 'down', '-v'])
+            raise
 
-    test_client = get_client(
-        host=test_host,
-        port=client_port,
-        username=test_user,
-        password=test_password,
-        secure=test_secure,
-    )
-    cluster_clause = f'ON CLUSTER "{test_cluster}"' if test_cluster else ''
-    for dbt_user in ch_test_users:
-        cmd = f'CREATE USER IF NOT EXISTS %s {cluster_clause} IDENTIFIED WITH sha256_hash BY %s'
-        test_client.command(
-            cmd,
-            (dbt_user, '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8'),
-        )
     # Make sure all system tables are available before starting tests
+    cluster_clause = f'''ON CLUSTER "{conn['cluster']}"''' if conn['cluster'] else ''
+    test_client = _get_test_client(conn)
     test_client.command(f"SYSTEM FLUSH LOGS {cluster_clause}")
+    test_client.close()
+
     yield {
-        'driver': test_driver,
-        'host': test_host,
-        'port': test_port,
-        'user': test_user,
-        'password': test_password,
-        'cluster': test_cluster,
-        'db_engine': test_db_engine,
-        'secure': test_secure,
-        'cluster_mode': test_cluster_mode,
+        'driver': conn['driver'],
+        'host': conn['host'],
+        'port': conn['port'],
+        'client_port': conn['client_port'],
+        'user': conn['user'],
+        'password': conn['password'],
+        'cluster': conn['cluster'],
+        'db_engine': os.environ.get('DBT_CH_TEST_DB_ENGINE', 'Shared' if test_cloud else ''),
+        'secure': conn['secure'],
+        'cluster_mode': os.environ.get('DBT_CH_TEST_CLUSTER_MODE', '').lower()
+        in ('1', 'true', 'yes'),
         'database': '',
     }
 
-    if docker:
-        try:
-            run_cmd(['docker', 'compose', '-f', compose_file, 'down', '-v'])
-        except Exception as e:
-            raise Exception('Failed to run docker compose while cleaning up: {}', str(e)) from e
-    else:
-        for test_user in ch_test_users:
-            test_client.command('DROP USER %s', (test_user,))
+    if docker_started:
+        # `down -v` also removes any leftover test state along with the volumes
+        run_cmd(['docker', 'compose', '-f', compose_file, 'down', '-v'])
 
 
 # The profile dictionary, used to write out profiles.yml
@@ -159,13 +200,39 @@ def dbt_profile_target(test_config):
 
 @pytest.fixture(scope="class")
 def prefix():
-    return f"dbt_clickhouse_{random.randint(1000, 9999)}"
+    # Must be unique across concurrent pytest-xdist workers: dbt derives both the
+    # test schema name and the shared logs/<prefix> directory from it.
+    worker = os.environ.get('PYTEST_XDIST_WORKER', 'gw0')
+    return f"dbt_clickhouse_{worker}_{uuid.uuid4().hex[:8]}"
 
 
 @pytest.fixture(scope="class")
 def unique_schema(request, prefix) -> str:
     test_file = request.module.__name__.split(".")[-1]
     return f"{prefix}_{test_file}_{int(time.time() * 1000)}"
+
+
+# Models configured with a custom schema create databases named
+# `<unique_schema>_<custom schema>`; dbt's own teardown only drops the schemas it
+# created itself, so those derived databases leak. The main `<unique_schema>` can
+# also survive: dbt's project teardown swallows drop_test_schema() errors after
+# commands like `dbt debug` (dbt-core #5041). This fixture sets up before (and thus
+# tears down after) the project fixture, sweeping whatever is left.
+@pytest.fixture(scope="class", autouse=True)
+def cleanup_derived_databases(test_config, unique_schema):
+    yield
+    test_client = _get_test_client(test_config)
+    cluster = test_config['cluster']
+    cluster_clause = f'ON CLUSTER "{cluster}"' if cluster else ''
+    try:
+        leaked = test_client.query(
+            'SELECT name FROM system.databases WHERE name = %s OR startsWith(name, %s)',
+            (unique_schema, f'{unique_schema}_'),
+        ).result_rows
+        for (db_name,) in leaked:
+            test_client.command(f'DROP DATABASE IF EXISTS "{db_name}" {cluster_clause} SYNC')
+    finally:
+        test_client.close()
 
 
 def run_cmd(cmd):

--- a/tests/integration/test_config.xml
+++ b/tests/integration/test_config.xml
@@ -52,6 +52,13 @@
         <coordination_settings>
             <operation_timeout_ms>10000</operation_timeout_ms>
             <session_timeout_ms>30000</session_timeout_ms>
+            <!-- All three raft members share one host with the test workers; spurious
+                 leader elections under CPU-starvation bursts drop keeper sessions and
+                 fail in-flight ON CLUSTER DDL (Code 999). Widen the election window so
+                 brief stalls don't trigger re-elections. -->
+            <heart_beat_interval_ms>1000</heart_beat_interval_ms>
+            <election_timeout_lower_bound_ms>4000</election_timeout_lower_bound_ms>
+            <election_timeout_upper_bound_ms>8000</election_timeout_upper_bound_ms>
         </coordination_settings>
 
         <raft_configuration>
@@ -72,6 +79,17 @@
             </server>
         </raft_configuration>
     </keeper_server>
+    <!-- The test suites issue thousands of ON CLUSTER DDLs per run (schemas, users,
+         SYSTEM FLUSH LOGS). With the default 7-day task_max_lifetime the DDL task
+         queue pins at max_tasks_in_queue and every new distributed DDL contends at
+         the cap, surfacing as sporadic "Coordination error: Operation timeout"
+         (Code 999). Prune finished tasks aggressively instead. -->
+    <distributed_ddl>
+        <path>/clickhouse/task_queue/ddl</path>
+        <task_max_lifetime>300</task_max_lifetime>
+        <cleanup_delay_period>15</cleanup_delay_period>
+        <max_tasks_in_queue>3000</max_tasks_in_queue>
+    </distributed_ddl>
     <zookeeper>
         <node index="1">
             <host>ch0</host>


### PR DESCRIPTION
## Summary of changes
**Test users (the DBT_TEST_USER problem)**
- Before: the three test users were created once, at the start of the whole test session, and their names were passed around through environment variables. This broke with parallel runs.
- Now: each test class that actually needs users creates its own three users, with random unique names, right before the class runs, and drops them when the class is done. The environment variables are still set (upstream dbt tests require them), but only for the duration of that class, and they are restored afterwards.
- Only the grants and dbt_clone test folders need users, so each of those folders got a tiny new conftest.py that turns this on. Everyone else never pays for it.

**Docker handling**
 - Sequential runs (the old default) still work exactly as before: set `DBT_CH_TEST_USE_DOCKER` and the test session starts and stops the ClickHouse cluster for you.
- Parallel runs must start the cluster themselves first (docker compose up -d). If you try to combine `DBT_CH_TEST_USE_DOCKER` with `-n`, you get a clear error explaining what to do instead of a confusing failure.
- CONTRIBUTING.md now documents both ways of running the tests.

**Making tests safe to run at the same time**
- Each test gets a schema name that includes the worker id plus a random suffix, so two workers can never step on each other's tables.
- `SYSTEM FLUSH LOGS` runs once per worker at startup, so system tables exist before tests query them.
- `pytest.ini`: makes pytest's doctest collector to skip conftest.py files (having several files with the same name broke imports).

**CI (GitHub Actions)**
- The workflows now start the ClickHouse cluster as their own step, then run `pytest with -n 5 --dist loadscope --timeout=300` for both the HTTP and native test jobs. `pytest-xdist` was added to dev_requirements.txt.

**Adapter fixes for flaky tests found by running in parallel**
- New shared helper retry_on_database_error in util.py.
- `dbclient.py`: command() and get_ch_setting() can now retry transient failures internally (the drivers implement the raw _command / _get_ch_setting versions). A failed check of the `allow_nondeterministic_mutations` setting is no longer cached for the whole process. Before, one bad read silently disabled lightweight deletes for every later connection in that process. Warning messages now say clearly what got disabled and show the real error.
- `nativeclient.py`: reading a setting now raises a proper error instead of returning None, which used to crash with a confusing message.

**ClickHouse test cluster config (test_config.xml)**
- Keeper election timings widened (heartbeat 1s, election window 4–8s): all three keeper nodes share one machine with the test workers, and short CPU stalls were triggering pointless leader elections that killed in-flight `ON CLUSTER` statements (the "Code 999" flake).
- The distributed DDL queue now cleans itself up (finished tasks kept 5 minutes instead of 7 days, cleanup every 15s instead of 60s): before, the queue filled up to its 1000-task cap and stayed there forever, causing sporadic timeouts.
