### PR TITLE
feat: opt-in create_if_not_exists for concurrent table creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Release [1.10.3], 2026-XX-XX
 
+#### New Features
+* Add an opt-in `create_if_not_exists` model config. When set, the model's table is created with `CREATE TABLE IF NOT EXISTS`, so independent concurrent dbt runs building the same table into a shared database no longer collide with `Code: 57 Table already exists` on first creation — the destination-table analogue of the temp-table fix in [#150](https://github.com/ClickHouse/dbt-clickhouse/issues/150). Defaults off (no behavior change); not intended for `Replicated` engines, where `CREATE TABLE IF NOT EXISTS` can raise `REPLICA_ALREADY_EXISTS` ([#722](https://github.com/ClickHouse/dbt-clickhouse/pull/722)).
+
 #### Improvements
 * Test against `dbt-core` 1.12 and widen the `dbt-adapters` upper bound to `<1.25.0` ([#718](https://github.com/ClickHouse/dbt-clickhouse/pull/718)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Release [1.10.3], 2026-XX-XX
 
 #### New Features
-* Add an opt-in `create_if_not_exists` model config. When set, the model's table is populated by a single atomic `CREATE TABLE IF NOT EXISTS ... AS SELECT`, so independent concurrent dbt runs building the same table into a shared database no longer collide with `Code: 57 Table already exists` on first creation — the destination-table analogue of the temp-table fix in [#150](https://github.com/ClickHouse/dbt-clickhouse/issues/150). A run that loses the create no-ops the whole statement (no separate `INSERT`), so rows are never doubled. Defaults off (no behavior change). Not supported with `contract`, `projections`, or `indexes` (which need the empty-create-then-insert path), and not intended for `Replicated` engines, where `CREATE TABLE IF NOT EXISTS` can raise `REPLICA_ALREADY_EXISTS` ([#722](https://github.com/ClickHouse/dbt-clickhouse/pull/722)).
+* Add an opt-in `create_if_not_exists` model config for first-creation races when concurrent runs build the same non-replicated table. It defaults to disabled and cannot be combined with contracts, projections, or indexes ([#722](https://github.com/ClickHouse/dbt-clickhouse/pull/722)).
 
 #### Improvements
 * Test against `dbt-core` 1.12 and widen the `dbt-adapters` upper bound to `<1.25.0` ([#718](https://github.com/ClickHouse/dbt-clickhouse/pull/718)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Release [1.10.3], 2026-XX-XX
 
 #### New Features
-* Add an opt-in `create_if_not_exists` model config. When set, the model's table is created with `CREATE TABLE IF NOT EXISTS`, so independent concurrent dbt runs building the same table into a shared database no longer collide with `Code: 57 Table already exists` on first creation — the destination-table analogue of the temp-table fix in [#150](https://github.com/ClickHouse/dbt-clickhouse/issues/150). Defaults off (no behavior change); not intended for `Replicated` engines, where `CREATE TABLE IF NOT EXISTS` can raise `REPLICA_ALREADY_EXISTS` ([#722](https://github.com/ClickHouse/dbt-clickhouse/pull/722)).
+* Add an opt-in `create_if_not_exists` model config. When set, the model's table is populated by a single atomic `CREATE TABLE IF NOT EXISTS ... AS SELECT`, so independent concurrent dbt runs building the same table into a shared database no longer collide with `Code: 57 Table already exists` on first creation — the destination-table analogue of the temp-table fix in [#150](https://github.com/ClickHouse/dbt-clickhouse/issues/150). A run that loses the create no-ops the whole statement (no separate `INSERT`), so rows are never doubled. Defaults off (no behavior change). Not supported with `contract`, `projections`, or `indexes` (which need the empty-create-then-insert path), and not intended for `Replicated` engines, where `CREATE TABLE IF NOT EXISTS` can raise `REPLICA_ALREADY_EXISTS` ([#722](https://github.com/ClickHouse/dbt-clickhouse/pull/722)).
 
 #### Improvements
 * Test against `dbt-core` 1.12 and widen the `dbt-adapters` upper bound to `<1.25.0` ([#718](https://github.com/ClickHouse/dbt-clickhouse/pull/718)).

--- a/dbt/include/clickhouse/macros/materializations/table.sql
+++ b/dbt/include/clickhouse/macros/materializations/table.sql
@@ -278,26 +278,18 @@
 {% macro clickhouse__create_table_as(temporary, relation, sql) -%}
     {% set has_contract = config.get('contract').enforced %}
     {%- set create_if_not_exists = config.get('create_if_not_exists', false) and not temporary -%}
-    {%- if create_if_not_exists -%}
-        {%- if has_contract or config.get('projections', default=[]) or config.get('indexes', default=[]) -%}
-            {{ exceptions.raise_compiler_error(
-                "create_if_not_exists is not supported together with contract, projections, or indexes.") }}
-        {%- endif -%}
-        {{ create_table_or_empty(temporary, relation, sql, has_contract, if_not_exists=true, empty=false) }}
-    {%- else -%}
-        {{ clickhouse__create_empty_table(temporary, relation, sql, has_contract) }}
-        {%- if not temporary %}
-            {{ clickhouse__insert_into(relation, sql, has_contract) }}
-        {%- endif %}
-    {%- endif -%}
+    {{ clickhouse__create_empty_table(temporary, relation, sql, has_contract, if_not_exists=create_if_not_exists) }}
+    {%- if not temporary %}
+        {{ clickhouse__insert_into(relation, sql, has_contract) }}
+    {%- endif %}
 {%- endmacro %}
 
 {#
     "CREATE TABLE" step extracted from clickhouse__create_table_as so it can be used by other macros.
 #}
-{% macro clickhouse__create_empty_table(temporary, relation, sql, has_contract, statement_name='create_table_empty') %}
+{% macro clickhouse__create_empty_table(temporary, relation, sql, has_contract, statement_name='create_table_empty', if_not_exists=false) %}
     {% call statement(statement_name) %}
-        {{ create_table_or_empty(temporary, relation, sql, has_contract) }}
+        {{ create_table_or_empty(temporary, relation, sql, has_contract, if_not_exists=if_not_exists) }}
     {% endcall %}
     {%- if not temporary %}
         {{ add_index_and_projections(relation) }}
@@ -381,7 +373,7 @@
     {% endif %}
 {% endmacro %}
 
-{% macro create_table_or_empty(temporary, relation, sql, has_contract, if_not_exists=false, empty=true) -%}
+{% macro create_table_or_empty(temporary, relation, sql, has_contract, if_not_exists=false) -%}
     {%- set sql_header = config.get('sql_header', none) -%}
 
     {{ sql_header if sql_header is not none }}
@@ -408,9 +400,7 @@
         {{ adapter.get_model_settings(model, config.get('engine', default='MergeTree')) }}
 
         {%- if not has_contract %}
-          {%- if empty %}
           empty
-          {%- endif %}
           as (
             {{ sql }}
           )

--- a/dbt/include/clickhouse/macros/materializations/table.sql
+++ b/dbt/include/clickhouse/macros/materializations/table.sql
@@ -277,10 +277,21 @@
 
 {% macro clickhouse__create_table_as(temporary, relation, sql) -%}
     {% set has_contract = config.get('contract').enforced %}
-    {{ clickhouse__create_empty_table(temporary, relation, sql, has_contract) }}
-    {%- if not temporary %}
-        {{ clickhouse__insert_into(relation, sql, has_contract) }}
-    {%- endif %}
+    {%- set create_if_not_exists = config.get('create_if_not_exists', false) and not temporary -%}
+    {%- if create_if_not_exists -%}
+        {%- if has_contract or config.get('projections', default=[]) or config.get('indexes', default=[]) -%}
+            {{ exceptions.raise_compiler_error(
+                "create_if_not_exists is not supported together with contract, projections, or indexes.") }}
+        {%- endif -%}
+        {% call statement('create_table') %}
+            {{ create_table_or_empty(temporary, relation, sql, has_contract) }}
+        {% endcall %}
+    {%- else -%}
+        {{ clickhouse__create_empty_table(temporary, relation, sql, has_contract) }}
+        {%- if not temporary %}
+            {{ clickhouse__insert_into(relation, sql, has_contract) }}
+        {%- endif %}
+    {%- endif -%}
 {%- endmacro %}
 
 {#
@@ -399,7 +410,9 @@
         {{ adapter.get_model_settings(model, config.get('engine', default='MergeTree')) }}
 
         {%- if not has_contract %}
+          {%- if not config.get('create_if_not_exists', false) %}
           empty
+          {%- endif %}
           as (
             {{ sql }}
           )

--- a/dbt/include/clickhouse/macros/materializations/table.sql
+++ b/dbt/include/clickhouse/macros/materializations/table.sql
@@ -283,9 +283,7 @@
             {{ exceptions.raise_compiler_error(
                 "create_if_not_exists is not supported together with contract, projections, or indexes.") }}
         {%- endif -%}
-        {% call statement('create_table') %}
-            {{ create_table_or_empty(temporary, relation, sql, has_contract, if_not_exists=true, empty=false) }}
-        {% endcall %}
+        {{ create_table_or_empty(temporary, relation, sql, has_contract, if_not_exists=true, empty=false) }}
     {%- else -%}
         {{ clickhouse__create_empty_table(temporary, relation, sql, has_contract) }}
         {%- if not temporary %}

--- a/dbt/include/clickhouse/macros/materializations/table.sql
+++ b/dbt/include/clickhouse/macros/materializations/table.sql
@@ -385,7 +385,7 @@
           {{ sql }}
         )
     {%- else %}
-        create table {{ relation }}
+        create table {% if config.get('create_if_not_exists', false) %}if not exists {% endif %}{{ relation }}
         {{ on_cluster_clause(relation)}}
         {%- if has_contract%}
           {{ get_assert_columns_equivalent(sql) }}

--- a/dbt/include/clickhouse/macros/materializations/table.sql
+++ b/dbt/include/clickhouse/macros/materializations/table.sql
@@ -284,7 +284,7 @@
                 "create_if_not_exists is not supported together with contract, projections, or indexes.") }}
         {%- endif -%}
         {% call statement('create_table') %}
-            {{ create_table_or_empty(temporary, relation, sql, has_contract) }}
+            {{ create_table_or_empty(temporary, relation, sql, has_contract, if_not_exists=true, empty=false) }}
         {% endcall %}
     {%- else -%}
         {{ clickhouse__create_empty_table(temporary, relation, sql, has_contract) }}
@@ -383,7 +383,7 @@
     {% endif %}
 {% endmacro %}
 
-{% macro create_table_or_empty(temporary, relation, sql, has_contract) -%}
+{% macro create_table_or_empty(temporary, relation, sql, has_contract, if_not_exists=false, empty=true) -%}
     {%- set sql_header = config.get('sql_header', none) -%}
 
     {{ sql_header if sql_header is not none }}
@@ -396,7 +396,7 @@
           {{ sql }}
         )
     {%- else %}
-        create table {% if config.get('create_if_not_exists', false) %}if not exists {% endif %}{{ relation }}
+        create table {% if if_not_exists %}if not exists {% endif %}{{ relation }}
         {{ on_cluster_clause(relation)}}
         {%- if has_contract%}
           {{ get_assert_columns_equivalent(sql) }}
@@ -410,7 +410,7 @@
         {{ adapter.get_model_settings(model, config.get('engine', default='MergeTree')) }}
 
         {%- if not has_contract %}
-          {%- if not config.get('create_if_not_exists', false) %}
+          {%- if empty %}
           empty
           {%- endif %}
           as (

--- a/tests/integration/adapter/incremental/test_create_if_not_exists.py
+++ b/tests/integration/adapter/incremental/test_create_if_not_exists.py
@@ -32,34 +32,50 @@ class TestCreateIfNotExists:
     def models(self):
         return {"cine_on.sql": cine_on, "cine_off.sql": cine_off}
 
-    def test_builds_with_correct_row_count(self, project):
-        run_dbt(["run"])
-        assert project.run_sql("select count() from cine_on", fetch="one")[0] == 10
-        assert project.run_sql("select count() from cine_off", fetch="one")[0] == 10
-
-    def test_flag_emits_atomic_create(self, project):
+    def test_first_build_uses_if_not_exists_and_separate_insert(self, project):
         run_dbt(["run", "--select", "cine_on cine_off"])
+        assert project.run_sql("select count() from cine_on", fetch="one")[0] == 10
+
         project.run_sql("system flush logs")
-        on_atomic = project.run_sql(
+        on_empty_ine = project.run_sql(
             "select count() from system.query_log where type = 'QueryFinish' "
             "and lower(query) like '%create table if not exists%cine_on%' "
-            "and lower(query) not like '%empty%'",
-            fetch="one",
-        )[0]
-        off_empty = project.run_sql(
-            "select count() from system.query_log where type = 'QueryFinish' "
-            "and lower(query) like '%create table%cine_off%' "
             "and lower(query) like '%empty%'",
             fetch="one",
         )[0]
-        assert on_atomic >= 1, "flagged model should CREATE ... IF NOT EXISTS ... AS SELECT"
-        assert off_empty >= 1, "default model should keep the empty-create-then-insert path"
-
-    def test_losing_create_does_not_double(self, project):
-        run_dbt(["run", "--select", "cine_on"])
-        assert project.run_sql("select count() from cine_on", fetch="one")[0] == 10
-        project.run_sql(
-            "create table if not exists cine_on engine = MergeTree order by id as "
-            "select toInt32(number) as id, concat('v', toString(number)) as val from numbers(10)"
+        on_separate_insert = project.run_sql(
+            "select count() from system.query_log where type = 'QueryFinish' "
+            "and lower(query) like '%insert into%cine_on%'",
+            fetch="one",
+        )[0]
+        off_plain = project.run_sql(
+            "select count() from system.query_log where type = 'QueryFinish' "
+            "and lower(query) like '%create table%cine_off%' "
+            "and lower(query) not like '%if not exists%'",
+            fetch="one",
+        )[0]
+        assert on_empty_ine >= 1, "flagged first build should CREATE TABLE IF NOT EXISTS ... empty"
+        assert on_separate_insert >= 1, (
+            "flagged first build must run a SEPARATE INSERT (not atomic CTAS)"
         )
-        assert project.run_sql("select count() from cine_on", fetch="one")[0] == 10
+        assert off_plain >= 1, "default model should CREATE TABLE without IF NOT EXISTS"
+
+    def test_two_concurrent_first_builds_keep_all_rows(self, project):
+        project.run_sql("drop table if exists cine_on")
+
+        def first_build(offset):
+            project.run_sql(
+                "create table if not exists cine_on engine = MergeTree order by id empty as "
+                f"(select toInt32(number) + {offset} as id, "
+                f"concat('v', toString(number + {offset})) as val from numbers(10))"
+            )
+            project.run_sql(
+                f"insert into cine_on select toInt32(number) + {offset} as id, "
+                f"concat('v', toString(number + {offset})) as val from numbers(10)"
+            )
+
+        first_build(0)  # invocation A: ids 0-9   (wins the create)
+        first_build(100)  # invocation B: ids 100-109 (create no-ops, insert still lands)
+
+        assert project.run_sql("select count() from cine_on", fetch="one")[0] == 20
+        assert project.run_sql("select count() from cine_on where id >= 100", fetch="one")[0] == 10

--- a/tests/integration/adapter/incremental/test_create_if_not_exists.py
+++ b/tests/integration/adapter/incremental/test_create_if_not_exists.py
@@ -1,0 +1,64 @@
+import pytest
+from dbt.tests.util import run_dbt
+
+# Same model, flag on vs off. The flag makes the table's CREATE use
+# `CREATE TABLE IF NOT EXISTS`, so independent concurrent runs building the same
+# table into a shared database don't collide on first creation (Code: 57).
+cine_on = """
+{{ config(
+        materialized='incremental',
+        incremental_strategy='delete+insert',
+        unique_key='id',
+        order_by=['id'],
+        create_if_not_exists=true,
+        settings={'allow_nullable_key': 1}
+    )
+}}
+select toInt32(number) as id, concat('v', toString(number)) as val from numbers(10)
+"""
+
+cine_off = """
+{{ config(
+        materialized='incremental',
+        incremental_strategy='delete+insert',
+        unique_key='id',
+        order_by=['id'],
+        settings={'allow_nullable_key': 1}
+    )
+}}
+select toInt32(number) as id, concat('v', toString(number)) as val from numbers(10)
+"""
+
+
+class TestCreateIfNotExists:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"cine_on.sql": cine_on, "cine_off.sql": cine_off}
+
+    def test_flag_emits_if_not_exists_ddl(self, project):
+        run_dbt(["run"])
+
+        # Both models build and hold data regardless of the flag.
+        assert project.run_sql("select count() from cine_on", fetch="one")[0] == 10
+        assert project.run_sql("select count() from cine_off", fetch="one")[0] == 10
+
+        # The flagged model's CREATE uses IF NOT EXISTS; the default one does not.
+        project.run_sql("system flush logs")
+        on_ddl = project.run_sql(
+            "select count() from system.query_log where type = 'QueryFinish' "
+            "and lower(query) like '%create table if not exists%cine_on%'",
+            fetch="one",
+        )[0]
+        off_ddl = project.run_sql(
+            "select count() from system.query_log where type = 'QueryFinish' "
+            "and lower(query) like '%create table%cine_off%' "
+            "and lower(query) not like '%if not exists%'",
+            fetch="one",
+        )[0]
+        assert on_ddl >= 1, "flagged model should CREATE TABLE IF NOT EXISTS"
+        assert off_ddl >= 1, "default model should CREATE TABLE without IF NOT EXISTS"
+
+    def test_rerun_is_idempotent(self, project):
+        run_dbt(["run", "--select", "cine_on"])
+        run_dbt(["run", "--select", "cine_on"])
+        assert project.run_sql("select count() from cine_on", fetch="one")[0] == 10

--- a/tests/integration/adapter/incremental/test_create_if_not_exists.py
+++ b/tests/integration/adapter/incremental/test_create_if_not_exists.py
@@ -1,9 +1,6 @@
 import pytest
 from dbt.tests.util import run_dbt
 
-# Same model, flag on vs off. The flag makes the table's CREATE use
-# `CREATE TABLE IF NOT EXISTS`, so independent concurrent runs building the same
-# table into a shared database don't collide on first creation (Code: 57).
 cine_on = """
 {{ config(
         materialized='incremental',
@@ -35,30 +32,34 @@ class TestCreateIfNotExists:
     def models(self):
         return {"cine_on.sql": cine_on, "cine_off.sql": cine_off}
 
-    def test_flag_emits_if_not_exists_ddl(self, project):
+    def test_builds_with_correct_row_count(self, project):
         run_dbt(["run"])
-
-        # Both models build and hold data regardless of the flag.
         assert project.run_sql("select count() from cine_on", fetch="one")[0] == 10
         assert project.run_sql("select count() from cine_off", fetch="one")[0] == 10
 
-        # The flagged model's CREATE uses IF NOT EXISTS; the default one does not.
+    def test_flag_emits_atomic_create(self, project):
+        run_dbt(["run", "--select", "cine_on cine_off"])
         project.run_sql("system flush logs")
-        on_ddl = project.run_sql(
+        on_atomic = project.run_sql(
             "select count() from system.query_log where type = 'QueryFinish' "
-            "and lower(query) like '%create table if not exists%cine_on%'",
+            "and lower(query) like '%create table if not exists%cine_on%' "
+            "and lower(query) not like '%empty%'",
             fetch="one",
         )[0]
-        off_ddl = project.run_sql(
+        off_empty = project.run_sql(
             "select count() from system.query_log where type = 'QueryFinish' "
             "and lower(query) like '%create table%cine_off%' "
-            "and lower(query) not like '%if not exists%'",
+            "and lower(query) like '%empty%'",
             fetch="one",
         )[0]
-        assert on_ddl >= 1, "flagged model should CREATE TABLE IF NOT EXISTS"
-        assert off_ddl >= 1, "default model should CREATE TABLE without IF NOT EXISTS"
+        assert on_atomic >= 1, "flagged model should CREATE ... IF NOT EXISTS ... AS SELECT"
+        assert off_empty >= 1, "default model should keep the empty-create-then-insert path"
 
-    def test_rerun_is_idempotent(self, project):
+    def test_losing_create_does_not_double(self, project):
         run_dbt(["run", "--select", "cine_on"])
-        run_dbt(["run", "--select", "cine_on"])
+        assert project.run_sql("select count() from cine_on", fetch="one")[0] == 10
+        project.run_sql(
+            "create table if not exists cine_on engine = MergeTree order by id as "
+            "select toInt32(number) as id, concat('v', toString(number)) as val from numbers(10)"
+        )
         assert project.run_sql("select count() from cine_on", fetch="one")[0] == 10


### PR DESCRIPTION
## Summary
Fixes [#721](https://github.com/ClickHouse/dbt-clickhouse/issues/721). See CHANGELOG. Adds an opt-in `create_if_not_exists model` config; default off; **not** for Replicated engines.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A changelog entry was added following [Updating the Changelog](../CONTRIBUTING.md#updating-the-changelog) (user-facing, concise, PR link)
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
