### PR TITLE
ci: update checkout and setup-python to current majors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: 3.12
 

--- a/.github/workflows/steps_local_testing.yml
+++ b/.github/workflows/steps_local_testing.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set environment variables
         run: |
@@ -48,7 +48,7 @@ jobs:
         run: REPLICA_NUM=1 docker compose -f ${{ github.workspace }}/tests/integration/docker-compose.yml up -d
 
       - name: Setup Python ${{ inputs.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/test_cloud.yml
+++ b/.github/workflows/test_cloud.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/test_cloud_results.yml
+++ b/.github/workflows/test_cloud_results.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Placeholder
         run: |


### PR DESCRIPTION
Updates the GitHub-maintained actions in the test and lint workflows.

Changes:
- actions/checkout v3/v4 -> v7 and actions/setup-python v4/v5 -> v7 in lint.yml, steps_local_testing.yml, test_cloud.yml, test_cloud_results.yml

pypi.yml is left untouched since it is the release pipeline. setup-python v7 drops the pip-install input, which these workflows do not use. The python 3.11/3.12 matrix entries stay unchanged.

Validation:
- yamllint clean on the four changed workflows
- checkout v7.0.1 and setup-python v7.0.0 exist on the actions org releases

Scope: .github/workflows only, no source changes.