### PR TITLE
fix: Contract enforcement for FixedString(N) columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Add `lightweight_deletes_sync=3` to the default connection settings for `Shared` database engine so it only waits for active replicas (overridable via `custom_settings`). ([#715](https://github.com/ClickHouse/dbt-clickhouse/pull/715)).
 
 #### Bugs
-* Fix contract enforcement failing for `FixedString(N)` columns: the rendered data type collapsed to `String`, which no longer matches a `FixedString(N)` contract declaration ([#XXX](https://github.com/ClickHouse/dbt-clickhouse/pull/XXX)).
+* Fix contract enforcement failing for `FixedString(N)` columns: the rendered data type collapsed to `String`, which no longer matches a `FixedString(N)` contract declaration ([#727](https://github.com/ClickHouse/dbt-clickhouse/pull/727)).
 * Fixed the `delete+insert` incremental strategy occasionally missing deletes when the table being read had just received new data that the replica had not yet synced. The subquery now embeds `select_sequential_consistency=1` ([#715](https://github.com/ClickHouse/dbt-clickhouse/pull/715)).
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `lightweight_deletes_sync=3` to the default connection settings for `Shared` database engine so it only waits for active replicas (overridable via `custom_settings`). ([#715](https://github.com/ClickHouse/dbt-clickhouse/pull/715)).
 
 #### Bugs
+* Fix contract enforcement failing for `FixedString(N)` columns: the rendered data type collapsed to `String`, which no longer matches a `FixedString(N)` contract declaration ([#XXX](https://github.com/ClickHouse/dbt-clickhouse/pull/XXX)).
 * Fixed the `delete+insert` incremental strategy occasionally missing deletes when the table being read had just received new data that the replica had not yet synced. The subquery now embeds `select_sequential_consistency=1` ([#715](https://github.com/ClickHouse/dbt-clickhouse/pull/715)).
 
 

--- a/dbt/adapters/clickhouse/column.py
+++ b/dbt/adapters/clickhouse/column.py
@@ -55,7 +55,12 @@ class ClickHouseColumn(Column):
     @property
     def data_type(self) -> str:
         if self.is_string():
-            data_t = self.string_type(self.string_size())
+            # Parameterized FixedString must render exactly: contract enforcement
+            # compares data_type strings verbatim against YAML data_type declarations
+            if self.dtype.lower().startswith('fixedstring') and self.char_size is not None:
+                data_t = f'FixedString({self.char_size})'
+            else:
+                data_t = self.string_type(self.string_size())
         elif self.is_numeric():
             data_t = self.numeric_type(self.dtype, self.numeric_precision, self.numeric_scale)
         else:

--- a/dbt/adapters/clickhouse/column.py
+++ b/dbt/adapters/clickhouse/column.py
@@ -54,13 +54,12 @@ class ClickHouseColumn(Column):
 
     @property
     def data_type(self) -> str:
-        if self.is_string():
-            # Parameterized FixedString must render exactly: contract enforcement
-            # compares data_type strings verbatim against YAML data_type declarations
-            if self.dtype.lower().startswith('fixedstring') and self.char_size is not None:
-                data_t = f'FixedString({self.char_size})'
-            else:
-                data_t = self.string_type(self.string_size())
+        if self.is_fixed_string():
+            # Contract enforcement compares data_type strings verbatim against
+            # YAML data_type declarations, so the exact type must be preserved
+            data_t = self.fixedstring_type(self.string_size())
+        elif self.is_string():
+            data_t = self.string_type(self.string_size())
         elif self.is_numeric():
             data_t = self.numeric_type(self.dtype, self.numeric_precision, self.numeric_scale)
         else:
@@ -87,6 +86,9 @@ class ClickHouseColumn(Column):
             'mediumtext',
         ] or self.dtype.lower().startswith('fixedstring')
 
+    def is_fixed_string(self) -> bool:
+        return self.dtype.lower().startswith('fixedstring') and self.char_size is not None
+
     def is_integer(self) -> bool:
         return self.dtype.lower().startswith('int') or self.dtype.lower().startswith('uint')
 
@@ -108,6 +110,10 @@ class ClickHouseColumn(Column):
     @classmethod
     def string_type(cls, size: int) -> str:
         return 'String'
+
+    @classmethod
+    def fixedstring_type(cls, size: int) -> str:
+        return f'FixedString({size})'
 
     @classmethod
     def numeric_type(cls, dtype: str, precision: Any, scale: Any) -> str:

--- a/tests/integration/adapter/column_types/test_column_types.py
+++ b/tests/integration/adapter/column_types/test_column_types.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from dbt.adapters.clickhouse import ClickHouseColumn
 
 
@@ -19,8 +21,11 @@ class TestColumn:
         assert str_col.string_size() == 256
         fixed_str_col = verify_column('name', 'FixedString', True, False, False, False)
         assert fixed_str_col.string_size() == 256
-        fixed_str_col = verify_column('name', 'FixedString(16)', True, False, False, False)
+        fixed_str_col = verify_column(
+            'name', 'FixedString(16)', True, False, False, False, 'FixedString(16)'
+        )
         assert fixed_str_col.string_size() == 16
+        assert fixed_str_col.data_type == 'FixedString(16)'
         verify_column('name', 'Decimal(6, 6)', False, True, False, False)
         verify_column('name', 'Float32', False, False, True, False)
         verify_column('name', 'Float64', False, False, True, False)
@@ -60,7 +65,7 @@ class TestColumn:
         verify_column_types(col, True, False, False, False)
         assert (
             repr(col)
-            == '<ClickhouseColumn name (LowCardinality(Nullable(String)), is nullable: True)>'
+            == '<ClickhouseColumn name (LowCardinality(Nullable(FixedString(16))), is nullable: True)>'
         )
 
     def test_map_type(self):
@@ -75,9 +80,17 @@ class TestColumn:
 
 
 def verify_column(
-    name: str, dtype: str, is_string: bool, is_numeric: bool, is_float: bool, is_int: bool
+    name: str,
+    dtype: str,
+    is_string: bool,
+    is_numeric: bool,
+    is_float: bool,
+    is_int: bool,
+    expected_data_type: Optional[str] = None,
 ) -> ClickHouseColumn:
-    data_type = 'String' if is_string else dtype
+    if expected_data_type is None:
+        expected_data_type = 'String' if is_string else dtype
+    data_type = expected_data_type
     col = ClickHouseColumn(column=name, dtype=dtype)
     verify_column_types(col, is_string, is_numeric, is_float, is_int)
     assert repr(col) == f'<ClickhouseColumn {name} ({data_type}, is nullable: False)>'

--- a/tests/integration/adapter/constraints/test_constraints.py
+++ b/tests/integration/adapter/constraints/test_constraints.py
@@ -64,6 +64,7 @@ class ClickHouseContractColumnsEqual:
         return [
             ["1::Int32", "Int32", "Int32"],
             ["'1'", "String", "String"],
+            ["toFixedString('1', 16)", "FixedString(16)", "FixedString(16)"],
             ["true", "Bool", "Bool"],
             ["'2013-11-03'::DateTime", "DateTime", "DateTime"],
             ["['a','b','c']", "Array(String)", "Array(String)"],

--- a/tests/integration/adapter/constraints/test_constraints.py
+++ b/tests/integration/adapter/constraints/test_constraints.py
@@ -109,6 +109,29 @@ class ClickHouseContractColumnsEqual:
             ]
             assert all([(exp in log_output or exp.upper() in log_output) for exp in expected])
 
+    def test__contract_fixedstring_string_mismatch(self, project):
+        # A String contract must not silently pass against a FixedString(N) model
+        # column: it previously passed preflight and broke later incremental runs (#726)
+        write_file(
+            my_model_data_type_sql.format(sql_value="toFixedString('1', 16)"),
+            "models",
+            "my_model_data_type.sql",
+        )
+        write_file(
+            model_data_type_schema_yml.format(data_type='String'),
+            "models",
+            "contract_schema.yml",
+        )
+
+        _, log_output = run_dbt_and_capture(["run", "-s", "my_model_data_type"], expect_pass=False)
+        expected = [
+            "wrong_data_type_column_name",
+            "FixedString(16)",
+            "String",
+            "data type mismatch",
+        ]
+        assert all([(exp in log_output or exp.upper() in log_output) for exp in expected])
+
     def test__contract_correct_column_data_types(self, project, data_types):
         for sql_column_value, schema_data_type, _ in data_types:
             # Write parametrized data_type to sql file

--- a/tests/integration/adapter/incremental/test_schema_change.py
+++ b/tests/integration/adapter/incremental/test_schema_change.py
@@ -230,3 +230,91 @@ class TestReordering:
         result = project.run_sql(f"select * from {model} order by col_1", fetch="all")
         assert result[0][1] == 1
         assert result[3][1] == 4
+
+
+fixed_string_append_sql = """
+{{
+    config(
+        materialized='%s',
+        unique_key='col_1',
+        on_schema_change='append_new_columns'
+    )
+}}
+
+{%% if not is_incremental() %%}
+select
+    number as col_1,
+    toFixedString(toString(number + 1), 16) as col_2
+from numbers(3)
+{%% else %%}
+select
+    number as col_1,
+    toFixedString(toString(number + 1), 16) as col_2,
+    toFixedString(toString(number + 2), 16) as col_3
+from numbers(2, 3)
+{%% endif %%}
+"""
+
+fixed_string_sync_sql = """
+{{
+    config(
+        materialized='%s',
+        unique_key='col_1',
+        on_schema_change='sync_all_columns'
+    )
+}}
+
+{%% if not is_incremental() %%}
+select
+    number as col_1,
+    toFixedString(toString(number + 1), 16) as col_2
+from numbers(3)
+{%% else %%}
+select
+    number as col_1,
+    toFixedString(toString(number + 1), 32) as col_2
+from numbers(2, 3)
+{%% endif %%}
+"""
+
+
+class TestFixedStringSchemaChange:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "fixed_string_append.sql": fixed_string_append_sql % "incremental",
+            "fixed_string_append_distributed.sql": fixed_string_append_sql
+            % "distributed_incremental",
+            "fixed_string_sync.sql": fixed_string_sync_sql % "incremental",
+            "fixed_string_sync_distributed.sql": fixed_string_sync_sql % "distributed_incremental",
+        }
+
+    def column_type(self, project, model, column):
+        result = project.run_sql(
+            f"select type from system.columns "
+            f"where database = currentDatabase() and table = '{model}' and name = '{column}'",
+            fetch="one",
+        )
+        return result[0]
+
+    @pytest.mark.parametrize("model", ("fixed_string_append", "fixed_string_append_distributed"))
+    def test_append(self, project, model):
+        if "distributed" in model and os.environ.get('DBT_CH_TEST_CLUSTER', '').strip() == '':
+            pytest.skip("Not on a cluster")
+        run_dbt(["run", "--select", model])
+        run_dbt(["run", "--select", model])
+        # The ALTER that adds col_3 must use the exact type; the collapsed String
+        # rendering silently widened the column instead
+        assert self.column_type(project, model, 'col_3') == 'FixedString(16)'
+        # With the collapsed rendering, this run failed the raw-dtype drift check
+        run_dbt(["run", "--select", model])
+
+    @pytest.mark.parametrize("model", ("fixed_string_sync", "fixed_string_sync_distributed"))
+    def test_sync(self, project, model):
+        if "distributed" in model and os.environ.get('DBT_CH_TEST_CLUSTER', '').strip() == '':
+            pytest.skip("Not on a cluster")
+        run_dbt(["run", "--select", model])
+        run_dbt(["run", "--select", model])
+        # The MODIFY COLUMN that widens col_2 must use the exact type, not String
+        assert self.column_type(project, model, 'col_2') == 'FixedString(32)'
+        run_dbt(["run", "--select", model])


### PR DESCRIPTION
Fixes #726

## Problem

`ClickHouseColumn.data_type` rendered every string-family column as `String` because `string_type()` ignores its size argument, so `FixedString(N)` collapsed to `String`. Contract enforcement compares `data_type` strings verbatim against YAML `data_type` declarations, which produced two bugs (#726):

- a `FixedString(N)` contract failed against a `FixedString(N)` model column with "data type mismatch"
- a `String` contract silently passed against a `FixedString(N)` column; the table was then created with a `String` column while the model produces `FixedString(N)`, and later incremental runs failed with a misleading `New column types: ['col String']` error, since the drift message renders the type through the same collapsing property

## Change

`data_type` now renders parameterized `FixedString(N)` exactly (`FixedString(16)` instead of `String`). Bare `FixedString` (not a valid ClickHouse type) and plain `String` keep their previous rendering, and `string_type()`/`string_size()` are unchanged, so schema-expansion checks (`can_expand_to`) are unaffected.

## Side effects (all improvements)

- `append_new_columns`/`sync_all_columns` ALTERs now use the exact type (`ADD/MODIFY COLUMN ... FixedString(N)` is valid ClickHouse DDL) instead of silently widening the column to `String`. The row in #704's Fusion parity table documents the old rendering and should be updated when this lands.
- `check_incremental_schema_changes` error messages now display the actual column type instead of a collapsed `String`.

## Testing

- Updated column unit tests to pin `FixedString(16)` rendering, plain and through `Nullable`/`LowCardinality` wrappers; fixed a stale assertion in `test_low_cardinality_nullable_type` that only held because of the collapse.
- Added a `FixedString(16)` case to the contract `data_types` fixture, exercised across table/view/distributed materializations (both matching and mismatching paths); verified the new test fails without the code fix.
- `make lint` clean; 92 unit/column tests and 21 contract integration tests pass against dockerized ClickHouse.
