### PR TITLE
docs: fix catalog support link in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 #### Bugs
 * Fixed the `delete+insert` incremental strategy occasionally missing deletes when the table being read had just received new data that the replica had not yet synced. The subquery now embeds `select_sequential_consistency=1` ([#715](https://github.com/ClickHouse/dbt-clickhouse/pull/715)).
 
+#### Repository maintenance
+* Fix the broken Catalog Support link in the README ([#733](https://github.com/ClickHouse/dbt-clickhouse/pull/733)).
+
 
 ### Release [1.10.2], 2026-08-13
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ pip install dbt-clickhouse
 - [x] ClickHouse-specific column configurations (Codec, TTL...)
 - [x] ClickHouse-specific table settings (indexes, projections...)
 
-All features up to dbt-core 1.10 are supported, including `--sample` flag and all deprecation warnings fixed for future releases. **Catalog integrations** (e.g., Iceberg) introduced in dbt 1.10 are not yet natively supported in the adapter, but workarounds are available. See the [Catalog Support section](/integrations/dbt/features-and-configurations#catalog-support) for details.
+All features up to dbt-core 1.10 are supported, including `--sample` flag and all deprecation warnings fixed for future releases. **Catalog integrations** (e.g., Iceberg) introduced in dbt 1.10 are not yet natively supported in the adapter, but workarounds are available. See the [Catalog Support section](https://clickhouse.com/docs/integrations/connectors/data-ingestion/etl-tools/dbt/features-and-configurations#catalog-support) for details.
 
 This adapter is still not available for use inside [dbt Cloud](https://docs.getdbt.com/docs/dbt-cloud/cloud-overview), but we expect to make it available soon. Please reach out to support to get more information on this.
 


### PR DESCRIPTION
### Description

Fixes the broken Catalog Support link in `README.md`.

The link used a site-root-relative path, which resolves against whichever host renders the file. On GitHub, and on the PyPI project page that renders this README as the package description, it pointed at `https://github.com/integrations/dbt/features-and-configurations` and returned 404. The path was also out of date with respect to the docs site, missing `/docs` and most of the current path.

Replaced it with the absolute URL, matching the documentation link already used earlier in the same README.

Before:

```
](/integrations/dbt/features-and-configurations#catalog-support)
```

After:

```
](https://clickhouse.com/docs/integrations/connectors/data-ingestion/etl-tools/dbt/features-and-configurations#catalog-support)
```

The equivalent paragraph in `docs/index.mdx` on the `codex/vendor-dbt-clickhouse-docs` branch (#728) already uses the current path, so this only brings the README copy back in line. A root-relative path stays correct there, since that file is rendered by the docs site, while the README needs the absolute form. The two changes touch different parts of `README.md` and do not conflict.

### Testing

Documentation only, no Python changed, so `make lint` and the test suite do not apply. Verified that the previous target returns 404 and that the new URL returns 200 with the `catalog-support` anchor present on the page.

Closes #732
