### PR TITLE
fix: apply tcp_keepalive values from a profile list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `lightweight_deletes_sync=3` to the default connection settings for `Shared` database engine so it only waits for active replicas (overridable via `custom_settings`). ([#715](https://github.com/ClickHouse/dbt-clickhouse/pull/715)).
 
 #### Bugs
+* Fixed `tcp_keepalive` failing profile validation when given explicit `[idle, interval, probes]` values, which left `true` (and its 7200s kernel default idle time) as the only usable setting ([#735](https://github.com/ClickHouse/dbt-clickhouse/pull/735)).
 * Fixed the `delete+insert` incremental strategy occasionally missing deletes when the table being read had just received new data that the replica had not yet synced. The subquery now embeds `select_sequential_consistency=1` ([#715](https://github.com/ClickHouse/dbt-clickhouse/pull/715)).
 
 #### Repository maintenance

--- a/dbt/adapters/clickhouse/credentials.py
+++ b/dbt/adapters/clickhouse/credentials.py
@@ -62,10 +62,6 @@ class ClickHouseCredentials(Credentials):
             )
         self.database = ''
 
-        # clickhouse_driver expects tcp_keepalive to be a tuple if it's not a boolean
-        if isinstance(self.tcp_keepalive, list):
-            self.tcp_keepalive = tuple(self.tcp_keepalive)
-
     def _connection_keys(self):
         return (
             'driver',

--- a/dbt/adapters/clickhouse/nativeclient.py
+++ b/dbt/adapters/clickhouse/nativeclient.py
@@ -76,7 +76,7 @@ class ChNativeClient(ChClientWrapper):
             sync_request_timeout=credentials.sync_request_timeout,
             compress_block_size=credentials.compress_block_size,
             compression=False if credentials.compression == '' else credentials.compression,
-            tcp_keepalive=credentials.tcp_keepalive,
+            tcp_keepalive=self._get_tcp_keepalive(credentials),
             settings=self._conn_settings,
         )
         try:
@@ -84,6 +84,14 @@ class ChNativeClient(ChClientWrapper):
         except (SocketTimeoutError, NetworkError) as ex:
             raise ChRetryableException(str(ex)) from ex
         return client
+
+    def _get_tcp_keepalive(self, credentials: ClickHouseCredentials):
+        # clickhouse_driver only applies the idle/interval/probe values when given a tuple
+        return (
+            tuple(credentials.tcp_keepalive)
+            if isinstance(credentials.tcp_keepalive, list)
+            else credentials.tcp_keepalive
+        )
 
     def _set_client_database(self):
         # After we know the database exists, reconnect to that database if appropriate

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from dbt.adapters.clickhouse.credentials import ClickHouseCredentials
+from dbt.adapters.clickhouse.nativeclient import ChNativeClient
+
+
+def _credentials(**kwargs):
+    return ClickHouseCredentials(
+        host='localhost',
+        port=9000,
+        user='default',
+        password='',
+        schema='default',
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize('tcp_keepalive', [False, True, [60, 30, 3]])
+def test_tcp_keepalive_validates(tcp_keepalive):
+    credentials = _credentials(tcp_keepalive=tcp_keepalive)
+
+    ClickHouseCredentials.validate(credentials.to_dict(omit_none=True))
+
+    assert credentials.tcp_keepalive == tcp_keepalive
+
+
+@pytest.mark.parametrize(
+    'tcp_keepalive,expected',
+    [(False, False), (True, True), ([60, 30, 3], (60, 30, 3))],
+)
+def test_tcp_keepalive_passed_to_driver(tcp_keepalive, expected):
+    client = ChNativeClient.__new__(ChNativeClient)
+    client._conn_settings = {}
+
+    with patch('clickhouse_driver.Client', MagicMock()) as mock_client:
+        client._create_client(_credentials(tcp_keepalive=tcp_keepalive))
+
+    assert mock_client.call_args.kwargs['tcp_keepalive'] == expected


### PR DESCRIPTION
## Summary

Setting explicit keepalive values in a profile currently fails to load:

```yaml
tcp_keepalive: [60, 30, 3]
```
```
Runtime Error
  at path ['tcp_keepalive']: (60, 30, 3) is not valid under any of the given schemas
```

`__post_init__` casts the list to a tuple, but profile validation runs on `credentials.to_dict(omit_none=True)`, and jsonschema only treats a `list` as `"array"`. So the tuple never validates and only `tcp_keepalive: true` is usable.

That leaves the option effectively unusable, because `true` sets `SO_KEEPALIVE` without `TCP_KEEPIDLE/INTVL/CNT`, so the socket falls back to the kernel default of 7200s idle. On a connection behind a NAT gateway or load balancer with a shorter idle timeout, a long-running query has its connection dropped silently and the client blocks until `send_receive_timeout`.

The cast moves to `nativeclient`, where `clickhouse_driver` requires a tuple. Passing it a list is not an option: `Connection._set_keepalive` returns early for any non-tuple, so the values are silently ignored.

Verified against a live server:

```
tcp_keepalive=True         -> SO_KEEPALIVE=1 IDLE=7200 INTVL=75 CNT=9
tcp_keepalive=[60, 30, 3]  -> SO_KEEPALIVE=1 IDLE=7200 INTVL=75 CNT=9   (silently ignored)
tcp_keepalive=(60, 30, 3)  -> SO_KEEPALIVE=1 IDLE=60   INTVL=30  CNT=3
```

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A changelog entry was added following [Updating the Changelog](../CONTRIBUTING.md#updating-the-changelog) (user-facing, concise, PR link)